### PR TITLE
Fix crash when formatting svelte files that have "let:class".

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -391,7 +391,7 @@ export const parsers = {
 
 function transformSvelte(ast, { env, changes }) {
   for (let attr of ast.attributes ?? []) {
-    if (attr.name === 'class') {
+    if (attr.name === 'class' && attr.type === 'Attribute') {
       for (let i = 0; i < attr.value.length; i++) {
         let value = attr.value[i]
         if (value.type === 'Text') {

--- a/tests/test.js
+++ b/tests/test.js
@@ -156,6 +156,7 @@ let tests = {
     t`<div class={\`${yes} \${'${yes}' + \`${yes}\`} ${yes}\`} />`,
     t`<div class={\`${no}\${someVar}${no}\`} />`,
     t`<div class="${yes} {\`${yes}\`}" />`,
+    t`<div let:class={clazz} class="${yes} {clazz}" />`,
     [
       `<div class="sm:block uppercase flex{someVar}" />`,
       `<div class="uppercase sm:block flex{someVar}" />`,


### PR DESCRIPTION
Hi there, I encountered a crash when running the plugin on a svelte file that has a slot component like this:

```svelte
  <p
    slot="test"
    let:class={className}
    class="h-full w-full p-2 backdrop-blur-0 {className}"
  />
```

Below was the error message and I've got a repro [here](https://github.com/chrsep/tailwind-prettier-sveltekit-repro):

![image](https://user-images.githubusercontent.com/8491552/151141610-98a1b5aa-b24c-441f-adb7-03d69918a9f6.png)

I found that the plugin was trying to read the "value" attribute from the let directive, which is always undefined. So to avoid this, I added a check to make sure that the sorting only runs on the class attributes, not on a directive named class such as `let:class={className}`.