### PR TITLE
Fix error when no Prettier options provided

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ function sortClasses(
 function createParser(original, transform) {
   return {
     ...original,
-    parse(text, parsers, options) {
+    parse(text, parsers, options = {}) {
       let ast = original.parse(text, parsers, options)
       let tailwindConfigPath = '__default__'
       let tailwindConfig = {}


### PR DESCRIPTION
Fixes #40

This PR adds a default value for the `options` parameter as sometimes this can be `undefined`