### PR TITLE
Fix Tailwind config file resolution when Prettier config file is not present

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@tailwindcss/line-clamp": "^0.3.0",
         "cpy-cli": "^3.1.1",
         "esbuild": "^0.14.11",
+        "escalade": "^3.1.1",
         "import-fresh": "^3.3.0",
         "import-from": "^4.0.0",
         "jest": "^27.4.7",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "predev": "npm run _pre",
     "dev": "npm run _esbuild -- --watch",
     "test": "jest",
-    "prepublishOnly": "npm run build && npm test && node scripts/copy-licenses.js"
+    "prepublishOnly": "npm run build && npm test && node scripts/copy-licenses.js",
+    "format": "prettier \"src/**/*.js\" \"tests/test.js\" --write --print-width 80 --single-quote --no-semi --plugin-search-dir ./tests"
   },
   "devDependencies": {
     "@tailwindcss/line-clamp": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@tailwindcss/line-clamp": "^0.3.0",
     "cpy-cli": "^3.1.1",
     "esbuild": "^0.14.11",
+    "escalade": "^3.1.1",
     "import-fresh": "^3.3.0",
     "import-from": "^4.0.0",
     "jest": "^27.4.7",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  semi: false,
-  singleQuote: true,
-  plugins: ['.'],
-  pluginSearchDirs: ['./tests'], // disable plugin autoload
-}

--- a/src/index.js
+++ b/src/index.js
@@ -12,13 +12,13 @@ import resolveConfigFallback from 'tailwindcss/resolveConfig'
 import * as recast from 'recast'
 import * as astTypes from 'ast-types'
 import * as path from 'path'
-import * as fs from 'fs'
 import requireFrom from 'import-from'
 import requireFresh from 'import-fresh'
 import objectHash from 'object-hash'
 import * as svelte from 'prettier-plugin-svelte'
 import lineColumn from 'line-column'
 import jsesc from 'jsesc'
+import escalade from 'escalade/sync'
 
 let contextMap = new Map()
 
@@ -97,23 +97,35 @@ function createParser(original, transform) {
       let createContext = createContextFallback
       let generateRules = generateRulesFallback
 
+      let baseDir
       let prettierConfigPath = prettier.resolveConfigFile.sync(options.filepath)
-      let baseDir = prettierConfigPath
-        ? path.dirname(prettierConfigPath)
-        : process.env.VSCODE_CWD ?? process.cwd()
 
       if (options.tailwindConfig) {
+        baseDir = prettierConfigPath
+          ? path.dirname(prettierConfigPath)
+          : process.cwd()
         tailwindConfigPath = path.resolve(baseDir, options.tailwindConfig)
         tailwindConfig = requireFresh(tailwindConfigPath)
       } else {
-        let tailwindConfigPathJs = path.resolve(baseDir, 'tailwind.config.js')
-        let tailwindConfigPathCjs = path.resolve(baseDir, 'tailwind.config.cjs')
-        if (fs.existsSync(tailwindConfigPathJs)) {
-          tailwindConfigPath = tailwindConfigPathJs
-          tailwindConfig = requireFresh(tailwindConfigPathJs)
-        } else if (fs.existsSync(tailwindConfigPathCjs)) {
-          tailwindConfigPath = tailwindConfigPathCjs
-          tailwindConfig = requireFresh(tailwindConfigPathCjs)
+        baseDir = prettierConfigPath
+          ? path.dirname(prettierConfigPath)
+          : options.filepath
+          ? path.dirname(options.filepath)
+          : process.cwd()
+        let configPath
+        try {
+          configPath = escalade(baseDir, (_dir, names) => {
+            if (names.includes('tailwind.config.js')) {
+              return 'tailwind.config.js'
+            }
+            if (names.includes('tailwind.config.cjs')) {
+              return 'tailwind.config.cjs'
+            }
+          })
+        } catch {}
+        if (configPath) {
+          tailwindConfigPath = configPath
+          tailwindConfig = requireFresh(configPath)
         }
       }
 

--- a/tests/fixtures/basic/prettier.config.js
+++ b/tests/fixtures/basic/prettier.config.js
@@ -1,3 +1,1 @@
-module.exports = {
-  plugins: ['../../..'],
-}
+module.exports = {};

--- a/tests/fixtures/cjs/prettier.config.js
+++ b/tests/fixtures/cjs/prettier.config.js
@@ -1,3 +1,1 @@
-module.exports = {
-  plugins: ['../../..'],
-}
+module.exports = {};

--- a/tests/fixtures/no-prettier-config/index.html
+++ b/tests/fixtures/no-prettier-config/index.html
@@ -1,0 +1,1 @@
+<div class="sm:bg-tomato bg-red-500"></div>

--- a/tests/fixtures/no-prettier-config/tailwind.config.js
+++ b/tests/fixtures/no-prettier-config/tailwind.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  theme: {
+    extend: {
+      colors: {
+        tomato: 'tomato',
+      },
+    },
+  },
+}

--- a/tests/test.js
+++ b/tests/test.js
@@ -19,7 +19,14 @@ function format(str, options = {}) {
 function formatFixture(name) {
   let binPath = path.resolve(__dirname, '../node_modules/.bin/prettier')
   let filePath = path.resolve(__dirname, `fixtures/${name}/index.html`)
-  return execSync(`${binPath} ${filePath}`).toString().trim()
+  return execSync(
+    `${binPath} ${filePath} --plugin-search-dir ${__dirname} --plugin ${path.resolve(
+      __dirname,
+      '..'
+    )}`
+  )
+    .toString()
+    .trim()
 }
 
 let yes = '__YES__'
@@ -191,6 +198,12 @@ test('non-tailwind classes', () => {
   expect(
     format('<div class="sm:lowercase uppercase potato text-sm"></div>')
   ).toEqual('<div class="potato text-sm uppercase sm:lowercase"></div>')
+})
+
+test('no prettier config', () => {
+  expect(formatFixture('no-prettier-config')).toEqual(
+    '<div class="bg-red-500 sm:bg-tomato"></div>'
+  )
 })
 
 test('inferred config path', () => {


### PR DESCRIPTION
This PR fixes Tailwind config file resolution when no Prettier config file is present. Now, when the `tailwindConfig` option is not provided the plugin will search up the directory hierarchy from a "base" directory, looking for a config file. The base directory is determined in this order:

1. The directory containing the Prettier config file if there is one
2. The directory containing the current file (`options.filepath`), if provided
3. The current working directory (`process.cwd()`)

Additionally, the `VSCODE_CWD` environment variable is no longer used because its value is not necessarily equal to the directory that is currently open in VS Code, as originally thought.