### PR TITLE
Remove double whitespaces from class names

### DIFF
--- a/tests/test.js
+++ b/tests/test.js
@@ -83,6 +83,15 @@ let javascript = [
   t`;<div class={{ '${yes}': '${yes}' }['${yes}']} />`,
   t`;<div class />`,
   t`;<div class="" />`,
+  [';<div class="  sm:p-0   p-0 "></div>', ';<div class="p-0 sm:p-0"></div>'],
+  [
+    `;<div class={\`  sm:p-0   p-0 \`}></div>`,
+    `;<div class={\`p-0 sm:p-0\`}></div>`,
+  ],
+  [
+    `;<div class={\`  sm:p-0   p-0   \${someVar}    \`}></div>`,
+    `;<div class={\`p-0 sm:p-0 \${someVar}\`}></div>`,
+  ],
   [
     `;<div class={\`sm:block inline flex\${someVar}\`} />`,
     `;<div class={\`inline sm:block flex\${someVar}\`} />`,


### PR DESCRIPTION
TailwindCSS prettier plugin is sorting classes in order to keep class
order in sync in entire project. But it also transfer unnecessary
whitespaces that will be ignored by browser anyway.

Removing redundant whitespaces can make this plugin even nicer.

Examples:

```jsx
<div className={" p-0     sm:p-0"}></div> ==> <div className={"p-0 sm:p-0"}></div>
<div className={` p-0     sm:p-0 `}></div> ==> <div className={`p-0 sm:p-0`}></div>
```