### PR TITLE
Add partial support for Twin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -297,7 +297,7 @@ function transformJavaScript(ast, { env }) {
       if (!node.value) {
         return
       }
-      if (['class', 'className'].includes(node.name.name)) {
+      if (['class', 'className', 'tw'].includes(node.name.name)) {
         if (isStringLiteral(node.value)) {
           sortStringLiteral(node.value, { env })
         } else if (node.value.type === 'JSXExpressionContainer') {


### PR DESCRIPTION
Twin supports many ways of styling an element. This PR aims ONLY to support those that use ```tw=""```

Since Twin uses tw instead of className or class, the current version is incompatible.


```diff
-      if (['class', 'className'].includes(node.name.name)) {
+      if (['class', 'className', 'tw'].includes(node.name.name)) {
```