### PR TITLE
Add support for formatting `.astro` files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "editor.formatOnSave": false
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "line-column": "^1.0.2",
         "object-hash": "^2.2.0",
         "prettier": "^2.5.1",
-        "prettier-plugin-astro": "^0.4.0",
+        "prettier-plugin-astro": "^0.4.1",
         "prettier-plugin-svelte": "^2.7.0",
         "recast": "^0.20.5",
         "rimraf": "^3.0.2",
@@ -6022,9 +6022,9 @@
       }
     },
     "node_modules/prettier-plugin-astro": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.4.0.tgz",
-      "integrity": "sha512-/AlAuIWroqyRP9gh8eJmZYz+tgiPORTsjBzTR/gc5/ib1QeaHJLectXHVWgY8iJQj5wztUSTE1/ByAjcqQRkiw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.4.1.tgz",
+      "integrity": "sha512-AvYyg4WDnhmqH5S85EFgJAMU20p1lLypVt4sn4tuGW+lnPfWr70SaHZD9gevx20o3FnALgZxDu1enFSkN/MSwQ==",
       "dev": true,
       "dependencies": {
         "@astrojs/compiler": "^0.19.0",
@@ -12339,9 +12339,9 @@
       "dev": true
     },
     "prettier-plugin-astro": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.4.0.tgz",
-      "integrity": "sha512-/AlAuIWroqyRP9gh8eJmZYz+tgiPORTsjBzTR/gc5/ib1QeaHJLectXHVWgY8iJQj5wztUSTE1/ByAjcqQRkiw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.4.1.tgz",
+      "integrity": "sha512-AvYyg4WDnhmqH5S85EFgJAMU20p1lLypVt4sn4tuGW+lnPfWr70SaHZD9gevx20o3FnALgZxDu1enFSkN/MSwQ==",
       "dev": true,
       "requires": {
         "@astrojs/compiler": "^0.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "line-column": "^1.0.2",
         "object-hash": "^2.2.0",
         "prettier": "^2.5.1",
+        "prettier-plugin-astro": "^0.4.0",
         "prettier-plugin-svelte": "^2.7.0",
         "recast": "^0.20.5",
         "rimraf": "^3.0.2",
@@ -32,6 +33,12 @@
       "peerDependencies": {
         "prettier": ">=2.2.0"
       }
+    },
+    "node_modules/@astrojs/compiler": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-0.19.0.tgz",
+      "integrity": "sha512-8nvyxZTfCXLyRmYfTttpJT6EPhfBRg0/q4J/Jj3/pNPLzp+vs05ZdktsY6QxAREaOMAnNEtSqcrB4S5DsXOfRg==",
+      "dev": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.16.7",
@@ -913,6 +920,26 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgr/utils": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.3.0.tgz",
+      "integrity": "sha512-7dIJ9CRVzBnqyEl7diUHPUFJf/oty2SeoVzcMocc5PeOUDK9KGzvgIBjGRRzzlRDaOjh3ADwH0WeibQvi3ls2Q==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "is-glob": "^4.0.3",
+        "open": "^8.4.0",
+        "picocolors": "^1.0.0",
+        "tiny-glob": "^0.2.9",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -2198,6 +2225,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -3207,6 +3243,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "dev": true
+    },
     "node_modules/globby": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
@@ -3412,6 +3454,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
     },
     "node_modules/graceful-fs": {
       "version": "4.2.9",
@@ -3805,6 +3853,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extendable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
@@ -3917,6 +3980,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/isarray": {
@@ -5483,6 +5558,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+      "dev": true,
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -5915,15 +6007,34 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
         "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-astro": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.4.0.tgz",
+      "integrity": "sha512-/AlAuIWroqyRP9gh8eJmZYz+tgiPORTsjBzTR/gc5/ib1QeaHJLectXHVWgY8iJQj5wztUSTE1/ByAjcqQRkiw==",
+      "dev": true,
+      "dependencies": {
+        "@astrojs/compiler": "^0.19.0",
+        "prettier": "^2.7.1",
+        "sass-formatter": "^0.7.2",
+        "synckit": "^0.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || >=16.0.0",
+        "npm": ">=6.14.0"
       }
     },
     "node_modules/prettier-plugin-svelte": {
@@ -6337,6 +6448,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/s.color": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/s.color/-/s.color-0.0.15.tgz",
+      "integrity": "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==",
+      "dev": true
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -6357,6 +6474,15 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "node_modules/sass-formatter": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/sass-formatter/-/sass-formatter-0.7.5.tgz",
+      "integrity": "sha512-NKFP8ddjhUYi6A/iD1cEtzkEs91U61kzqe3lY9SVNuvX7LGc88xnEN0mmsWL7Ol//YTi2GL/ol7b9XZ2+hgXuA==",
+      "dev": true,
+      "dependencies": {
+        "suf-log": "^2.5.3"
+      }
     },
     "node_modules/saxes": {
       "version": "5.0.1",
@@ -6967,6 +7093,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/suf-log": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/suf-log/-/suf-log-2.5.3.tgz",
+      "integrity": "sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==",
+      "dev": true,
+      "dependencies": {
+        "s.color": "0.0.15"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7018,6 +7153,22 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "node_modules/synckit": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.7.3.tgz",
+      "integrity": "sha512-jNroMv7Juy+mJ/CHW5H6TzsLWpa1qck6sCHbkv8YTur+irSq2PjbvmGnm2gy14BUQ6jF33vyR4DPssHqmqsDQw==",
+      "dev": true,
+      "dependencies": {
+        "@pkgr/utils": "^2.3.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "3.0.23",
@@ -7094,6 +7245,16 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
       "dev": true
+    },
+    "node_modules/tiny-glob": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "dev": true,
+      "dependencies": {
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -7206,9 +7367,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
     "node_modules/type-check": {
@@ -7617,6 +7778,12 @@
     }
   },
   "dependencies": {
+    "@astrojs/compiler": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-0.19.0.tgz",
+      "integrity": "sha512-8nvyxZTfCXLyRmYfTttpJT6EPhfBRg0/q4J/Jj3/pNPLzp+vs05ZdktsY6QxAREaOMAnNEtSqcrB4S5DsXOfRg==",
+      "dev": true
+    },
     "@babel/code-frame": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
@@ -8293,6 +8460,20 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@pkgr/utils": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.3.0.tgz",
+      "integrity": "sha512-7dIJ9CRVzBnqyEl7diUHPUFJf/oty2SeoVzcMocc5PeOUDK9KGzvgIBjGRRzzlRDaOjh3ADwH0WeibQvi3ls2Q==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "is-glob": "^4.0.3",
+        "open": "^8.4.0",
+        "picocolors": "^1.0.0",
+        "tiny-glob": "^0.2.9",
+        "tslib": "^2.4.0"
       }
     },
     "@sinonjs/commons": {
@@ -9311,6 +9492,12 @@
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "dev": true
     },
+    "define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true
+    },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -10033,6 +10220,12 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
+    "globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "dev": true
+    },
     "globby": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
@@ -10206,6 +10399,12 @@
           }
         }
       }
+    },
+    "globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
     },
     "graceful-fs": {
       "version": "4.2.9",
@@ -10508,6 +10707,12 @@
         "kind-of": "^6.0.2"
       }
     },
+    "is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true
+    },
     "is-extendable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
@@ -10588,6 +10793,15 @@
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
+    },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
     },
     "isarray": {
       "version": "1.0.0",
@@ -11810,6 +12024,17 @@
         "mimic-fn": "^2.1.0"
       }
     },
+    "open": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+      "dev": true,
+      "requires": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      }
+    },
     "optionator": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -12108,10 +12333,22 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
+    },
+    "prettier-plugin-astro": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.4.0.tgz",
+      "integrity": "sha512-/AlAuIWroqyRP9gh8eJmZYz+tgiPORTsjBzTR/gc5/ib1QeaHJLectXHVWgY8iJQj5wztUSTE1/ByAjcqQRkiw==",
+      "dev": true,
+      "requires": {
+        "@astrojs/compiler": "^0.19.0",
+        "prettier": "^2.7.1",
+        "sass-formatter": "^0.7.2",
+        "synckit": "^0.7.0"
+      }
     },
     "prettier-plugin-svelte": {
       "version": "2.7.0",
@@ -12408,6 +12645,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "s.color": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/s.color/-/s.color-0.0.15.tgz",
+      "integrity": "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==",
+      "dev": true
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -12428,6 +12671,15 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "sass-formatter": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/sass-formatter/-/sass-formatter-0.7.5.tgz",
+      "integrity": "sha512-NKFP8ddjhUYi6A/iD1cEtzkEs91U61kzqe3lY9SVNuvX7LGc88xnEN0mmsWL7Ol//YTi2GL/ol7b9XZ2+hgXuA==",
+      "dev": true,
+      "requires": {
+        "suf-log": "^2.5.3"
+      }
     },
     "saxes": {
       "version": "5.0.1",
@@ -12928,6 +13180,15 @@
         "min-indent": "^1.0.0"
       }
     },
+    "suf-log": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/suf-log/-/suf-log-2.5.3.tgz",
+      "integrity": "sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==",
+      "dev": true,
+      "requires": {
+        "s.color": "0.0.15"
+      }
+    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -12964,6 +13225,16 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "synckit": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.7.3.tgz",
+      "integrity": "sha512-jNroMv7Juy+mJ/CHW5H6TzsLWpa1qck6sCHbkv8YTur+irSq2PjbvmGnm2gy14BUQ6jF33vyR4DPssHqmqsDQw==",
+      "dev": true,
+      "requires": {
+        "@pkgr/utils": "^2.3.0",
+        "tslib": "^2.4.0"
+      }
     },
     "tailwindcss": {
       "version": "3.0.23",
@@ -13020,6 +13291,16 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
       "dev": true
+    },
+    "tiny-glob": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "dev": true,
+      "requires": {
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
+      }
     },
     "tmpl": {
       "version": "1.0.5",
@@ -13107,9 +13388,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
     "type-check": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "line-column": "^1.0.2",
     "object-hash": "^2.2.0",
     "prettier": "^2.5.1",
+    "prettier-plugin-astro": "^0.4.0",
     "prettier-plugin-svelte": "^2.7.0",
     "recast": "^0.20.5",
     "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "line-column": "^1.0.2",
     "object-hash": "^2.2.0",
     "prettier": "^2.5.1",
-    "prettier-plugin-astro": "^0.4.0",
+    "prettier-plugin-astro": "^0.4.1",
     "prettier-plugin-svelte": "^2.7.0",
     "recast": "^0.20.5",
     "rimraf": "^3.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ import requireFrom from 'import-from'
 import requireFresh from 'import-fresh'
 import objectHash from 'object-hash'
 import * as svelte from 'prettier-plugin-svelte'
+import * as astro from 'prettier-plugin-astro'
 import lineColumn from 'line-column'
 import jsesc from 'jsesc'
 import escalade from 'escalade/sync'
@@ -447,6 +448,25 @@ export const parsers = {
     transformSvelte(ast.html, { env, changes })
     ast.changes = changes
   }),
+  astro: createParser(astro.parsers.astro, transformAstro)
+}
+
+function transformAstro(ast, { env, changes }) {
+  if (ast.type === "element") {
+    for (let attr of ast.attributes ?? []) {
+      if (attr.name === "class" && attr.type === "attribute") {
+        if (attr.kind === "quoted") {
+          attr.value = sortClasses(attr.value, {
+            env
+          });
+        }
+      }
+    }
+  }
+
+  for (let child of ast.children ?? []) {
+    transformAstro(child, { env, changes });
+  }
 }
 
 function transformSvelte(ast, { env, changes }) {

--- a/src/index.js
+++ b/src/index.js
@@ -454,12 +454,10 @@ export const parsers = {
 function transformAstro(ast, { env, changes }) {
   if (ast.type === "element") {
     for (let attr of ast.attributes ?? []) {
-      if (attr.name === "class" && attr.type === "attribute") {
-        if (attr.kind === "quoted") {
-          attr.value = sortClasses(attr.value, {
-            env
-          });
-        }
+      if (attr.name === "class" && attr.type === "attribute" && attr.kind === "quoted") {
+        attr.value = sortClasses(attr.value, {
+          env
+        });
       }
     }
   }

--- a/tests/test.js
+++ b/tests/test.js
@@ -159,10 +159,7 @@ let tests = {
   html,
   glimmer,
   lwc: html,
-  vue: [
-    ...vue,
-    t`<div :class="\`${yes} \${someVar} ${yes} \${'${yes}'}\`"></div>`,
-  ],
+  vue: [...vue, t`<div :class="\`${yes} \${someVar} ${yes} \${'${yes}'}\`"></div>`],
   angular: [
     ...html,
     t`<div [ngClass]="'${yes}'"></div>`,
@@ -182,14 +179,14 @@ let tests = {
   less: [...css, t`@apply ${yes} !important;`],
   babel: javascript,
   typescript: javascript,
-  "babel-ts": javascript,
+  'babel-ts': javascript,
   flow: javascript,
-  "babel-flow": javascript,
+  'babel-flow': javascript,
   espree: javascript,
   meriyah: javascript,
   mdx: javascript
     .filter((test) => !test.find((t) => /^\/\*/.test(t)))
-    .map((test) => test.map((t) => t.replace(/^;/, ""))),
+    .map((test) => test.map((t) => t.replace(/^;/, ''))),
   svelte: [
     t`<div class="${yes}" />`,
     t`<div class />`,
@@ -217,7 +214,7 @@ let tests = {
       `<div class="sm:p-0 p-0 {someVar}sm:block md:inline flex" />`,
       `<div class="p-0 sm:p-0 {someVar}sm:block flex md:inline" />`,
     ],
-    ["<div class={`sm:p-0\np-0`} />", "<div\n  class={`p-0\nsm:p-0`}\n/>"],
+    ['<div class={`sm:p-0\np-0`} />', '<div\n  class={`p-0\nsm:p-0`}\n/>'],
   ],
   astro: [
     ...html,

--- a/tests/test.js
+++ b/tests/test.js
@@ -213,6 +213,25 @@ let tests = {
     ],
     ['<div class={`sm:p-0\np-0`} />', '<div\n  class={`p-0\nsm:p-0`}\n/>'],
   ],
+  astro: [
+    ...html,
+    [
+      `{<div class="p-20 bg-red-100 w-full"></div>}`,
+      `{<div class="p-20 w-full bg-red-100"></div>}`,
+    ],
+    [
+      `<style>
+      h1 {
+        @apply p-20 w-full bg-fuchsia-50;
+      }
+    </style>`,
+      `<style>
+      h1 {
+        @apply p-20 w-full bg-fuchsia-50;
+      }
+    </style>`,
+    ],
+  ],
 }
 
 describe('parsers', () => {

--- a/tests/test.js
+++ b/tests/test.js
@@ -159,7 +159,10 @@ let tests = {
   html,
   glimmer,
   lwc: html,
-  vue: [...vue, t`<div :class="\`${yes} \${someVar} ${yes} \${'${yes}'}\`"></div>`],
+  vue: [
+    ...vue,
+    t`<div :class="\`${yes} \${someVar} ${yes} \${'${yes}'}\`"></div>`,
+  ],
   angular: [
     ...html,
     t`<div [ngClass]="'${yes}'"></div>`,
@@ -179,14 +182,14 @@ let tests = {
   less: [...css, t`@apply ${yes} !important;`],
   babel: javascript,
   typescript: javascript,
-  'babel-ts': javascript,
+  "babel-ts": javascript,
   flow: javascript,
-  'babel-flow': javascript,
+  "babel-flow": javascript,
   espree: javascript,
   meriyah: javascript,
   mdx: javascript
     .filter((test) => !test.find((t) => /^\/\*/.test(t)))
-    .map((test) => test.map((t) => t.replace(/^;/, ''))),
+    .map((test) => test.map((t) => t.replace(/^;/, ""))),
   svelte: [
     t`<div class="${yes}" />`,
     t`<div class />`,
@@ -214,28 +217,28 @@ let tests = {
       `<div class="sm:p-0 p-0 {someVar}sm:block md:inline flex" />`,
       `<div class="p-0 sm:p-0 {someVar}sm:block flex md:inline" />`,
     ],
-    ['<div class={`sm:p-0\np-0`} />', '<div\n  class={`p-0\nsm:p-0`}\n/>'],
+    ["<div class={`sm:p-0\np-0`} />", "<div\n  class={`p-0\nsm:p-0`}\n/>"],
   ],
   astro: [
     ...html,
     [
       `{<div class="p-20 bg-red-100 w-full"></div>}`,
-      `{<div class="p-20 w-full bg-red-100"></div>}`,
+      `{(<div class="w-full bg-red-100 p-20" />)}`,
     ],
     [
       `<style>
-      h1 {
-        @apply p-20 w-full bg-fuchsia-50;
-      }
-    </style>`,
+  h1 {
+    @apply bg-fuchsia-50 p-20 w-full;
+  }
+</style>`,
       `<style>
-      h1 {
-        @apply p-20 w-full bg-fuchsia-50;
-      }
-    </style>`,
+  h1 {
+    @apply w-full bg-fuchsia-50 p-20;
+  }
+</style>`,
     ],
   ],
-}
+};
 
 describe('parsers', () => {
   for (let parser in tests) {

--- a/tests/test.js
+++ b/tests/test.js
@@ -6,7 +6,10 @@ function format(str, options = {}) {
   return prettier
     .format(str, {
       pluginSearchDirs: [__dirname], // disable plugin autoload
-      plugins: [path.resolve(__dirname, '..')],
+      plugins: [
+        path.resolve(__dirname, '..'),
+        require('prettier-plugin-astro'),
+      ],
       semi: false,
       singleQuote: true,
       printWidth: 9999,

--- a/tests/test.js
+++ b/tests/test.js
@@ -7,8 +7,8 @@ function format(str, options = {}) {
     .format(str, {
       pluginSearchDirs: [__dirname], // disable plugin autoload
       plugins: [
+        require.resolve('prettier-plugin-astro'),
         path.resolve(__dirname, '..'),
-        require('prettier-plugin-astro'),
       ],
       semi: false,
       singleQuote: true,


### PR DESCRIPTION
Hello!

I'm Erika from the [Astro](https://astro.build/) team. [We love Tailwind](https://docs.astro.build/en/guides/integrations-guide/tailwind/) and would love to have support for Astro files inside this plugin. As such, well, here's a PR that adds it 😄

The support is pretty good, since we use other parsers for the different parts of the files, including expressions:

```astro
---
...
---

<!-- This will format, this is what this PR adds! -->
<div class="p-20 w-full bg-red-100"></div>

<!-- This will format, since it's parsed and printed by `babel-ts` -->
{<div class="p-20 w-full bg-red-100"></div>}

<!-- This will format, since it's parsed and printed by Prettier's CSS parsers (so works for scss too) -->
<style>
  h1 {
    @apply p-20 w-full bg-fuchsia-50;
  }
</style>
```

I hope we can get this to work, don't hesitate if there's anything needed from us to get this over the line!

Thank you