### PR TITLE
Add a "incompatibilities with prettier-plugin-astro" blurb

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,6 @@ The most popular example we know of is [prettier-plugin-svelte](https://github.c
 
 To work around this, we've bundled `prettier-plugin-svelte` directly into `prettier-plugin-tailwindcss`, so if you'd like to use this plugin with Svelte, just uninstall `prettier-plugin-svelte` and everything should work as expected.
 
+We've also bundled in [prettier-plugin-astro](https://github.com/withastro/prettier-plugin-astro) as of `v0.1.14`, so just uninstall `prettier-plugin-astro` and everything should work as expected
+
 If you discover any other incompatibilities, please share them in [this issue](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/issues/31) and hopefully we can figure out a way to make it work.


### PR DESCRIPTION
I realize the version containing prettier-plugin-astro hasn't been released, so I made a guess at the version #; this'll wait to get merged until then perhaps.

Following up on https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/87