### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "prettier-plugin-tailwindcss",
   "version": "0.1.13",
   "description": "A Prettier plugin for sorting Tailwind CSS classes.",
+  "license": "MIT",
   "main": "dist/index.js",
   "files": [
     "dist"


### PR DESCRIPTION
Currently, this package is missing the `license` field in `package.json`; this causes the license to be "none" on npm (see https://www.npmjs.com/package/prettier-plugin-tailwindcss/v/0.1.13).

This PR adds a license value corresponding to the MIT license file already present in the repository.