### PR TITLE
Fallback to js expression parsing for angular directives if needed

### DIFF
--- a/tests/test.js
+++ b/tests/test.js
@@ -173,6 +173,10 @@ let tests = {
     t`<div [ngClass]="{ '${yes}': true }"></div>`,
     t`<div [ngClass]="clsx('${yes}')"></div>`,
     t`<div [ngClass]="{ '${yes}': (some.thing | urlPipe: { option: true } | async), '${yes}': true }"></div>`,
+    t`<div [ngClass]="{ '${yes}': foo && bar?.['baz'] }" class="${yes}"></div>`,
+
+    // TODO: Enable this test — it causes console noise but not a failure
+    // t`<div [ngClass]="{ '${no}': foo && definitely&a:syntax*error }" class="${yes}"></div>`,
   ],
   css: [...css, t`@apply ${yes} !important;`],
   scss: [...css, t`@apply ${yes} #{!important};`],


### PR DESCRIPTION
Angular's internal `__ng_directive` parser outright fails when given an expression like `foo?.[anything_can_go_here]` so we'll try it and then fall back to JS expression parsing if it fails.

Fixes #91