### PR TITLE
update readme for tailwind.config.cjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ module.exports = {
 }
 ```
 
+Or, with vite:
+
+```js
+// prettier.config.js
+module.exports = {
+  tailwindConfig: './styles/tailwind.config.cjs',
+}
+```
+
 If a local configuration file cannot be found the plugin will fallback to the default Tailwind configuration.
 
 ## Compatibility with other Prettier plugins


### PR DESCRIPTION
Hey,
This PR simply adds extra explanation in README, as creating an react-tailwind project with Vite results in a `tailwind-config.cjs` file instead of a `tailwind-config.js` one.