### PR TITLE
Add prettier plugins to peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,10 @@
       "devDependencies": {
         "@prettier/plugin-php": "^0.19.2",
         "@prettier/plugin-pug": "^2.3.0",
-        "@shopify/prettier-plugin-liquid": "^0.4.0",
-        "@shufo/prettier-plugin-blade": "^1.8.0",
+        "@shopify/prettier-plugin-liquid": "^1.0.3",
+        "@shufo/prettier-plugin-blade": "^1.8.4",
         "@tailwindcss/line-clamp": "^0.3.0",
-        "@trivago/prettier-plugin-sort-imports": "^3.3.0",
+        "@trivago/prettier-plugin-sort-imports": "^3.4.0",
         "cpy-cli": "^3.1.1",
         "esbuild": "^0.14.11",
         "escalade": "^3.1.1",
@@ -32,20 +32,75 @@
         "prettier-plugin-import-sort": "^0.0.7",
         "prettier-plugin-jsdoc": "^0.4.2",
         "prettier-plugin-organize-attributes": "^0.0.5",
-        "prettier-plugin-organize-imports": "^3.1.0",
+        "prettier-plugin-organize-imports": "^3.2.1",
         "prettier-plugin-style-order": "^0.2.2",
-        "prettier-plugin-svelte": "^2.7.0",
+        "prettier-plugin-svelte": "^2.9.0",
         "prettier-plugin-twig-melody": "^0.4.6",
         "recast": "^0.20.5",
         "rimraf": "^3.0.2",
-        "svelte": "^3.46.4",
+        "svelte": "^3.55.0",
         "tailwindcss": "^3.0.23"
       },
       "engines": {
         "node": ">=12.17.0"
       },
       "peerDependencies": {
-        "prettier": ">=2.2.0"
+        "@prettier/plugin-php": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@shufo/prettier-plugin-blade": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "prettier": ">=2.2.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-import-sort": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-style-order": "*",
+        "prettier-plugin-svelte": "*",
+        "prettier-plugin-twig-melody": "*"
+      },
+      "peerDependenciesMeta": {
+        "@prettier/plugin-php": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-import-sort": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-style-order": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        },
+        "prettier-plugin-twig-melody": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -698,13 +753,13 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.20.1.tgz",
-      "integrity": "sha512-CGulbEDcg/ND1Im7fUNRZdGXmX2MTWVVZacQi/6DiKE5HNwZ3aVTm5PV4lO8HHz0B2h8WQyvKKjbX5XgTtydsg==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.20.7.tgz",
+      "integrity": "sha512-jr9lCZ4RbRQmCR28Q8U8Fu49zvFqLxTY9AMOUz+iyMohMoAgpEcVxY+wJNay99oXOpOcCTODkk70NDN2aaJEeg==",
       "dev": true,
       "dependencies": {
         "core-js-pure": "^3.25.1",
-        "regenerator-runtime": "^0.13.10"
+        "regenerator-runtime": "^0.13.11"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1780,9 +1835,9 @@
       }
     },
     "node_modules/@shopify/prettier-plugin-liquid": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@shopify/prettier-plugin-liquid/-/prettier-plugin-liquid-0.4.3.tgz",
-      "integrity": "sha512-WCs7OEWvsgEdowP095DSFfCSQQedLNtppZPEK7pXINQ7WaKlmJUgATzxggTihf5wi9LyhJZdJmvnjVw6fxE+tA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@shopify/prettier-plugin-liquid/-/prettier-plugin-liquid-1.0.3.tgz",
+      "integrity": "sha512-rKrXXaxz0X8r2pep21AA2ssAYKmbiy7qPg/4cyo/ZXSsUFiGhzzzkxw7WXKFkdL/8zxv7SSm3+d1poiPoJvsTA==",
       "dev": true,
       "dependencies": {
         "html-styles": "^1.0.0",
@@ -1794,12 +1849,12 @@
       }
     },
     "node_modules/@shufo/prettier-plugin-blade": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@shufo/prettier-plugin-blade/-/prettier-plugin-blade-1.8.0.tgz",
-      "integrity": "sha512-inWakYel77plbfWcFlA5WQO78k4TgAh0IqPF+XeGulGZiuqDg7FtUqL3ZaHMGMcBfV805YVfRM7WqtfOQ7PPVQ==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@shufo/prettier-plugin-blade/-/prettier-plugin-blade-1.8.4.tgz",
+      "integrity": "sha512-mzkQODvsnomJSXTQGeGvRCn1F0M6SLY2De89mdVIpp17w3PdUWWLweextmmm++k6BVUx0Ok+kUqePSG9NceKXg==",
       "dev": true,
       "dependencies": {
-        "blade-formatter": "^1.31.0",
+        "blade-formatter": "^1.32.3",
         "prettier": "^2.6.2",
         "synckit": "^0.8.4"
       },
@@ -2272,9 +2327,9 @@
       "dev": true
     },
     "node_modules/ajv": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
-      "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2878,9 +2933,9 @@
       "dev": true
     },
     "node_modules/blade-formatter": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/blade-formatter/-/blade-formatter-1.31.0.tgz",
-      "integrity": "sha512-PU5tlHoydJ7HWCdwaXRvdAxHdIraN63abIteGKZujqW3YzHzOkk2H7t3jFjz682mlBsbmjBjjcsguiyd0UTZHg==",
+      "version": "1.32.3",
+      "resolved": "https://registry.npmjs.org/blade-formatter/-/blade-formatter-1.32.3.tgz",
+      "integrity": "sha512-rVBOEooGBYjZ60eODVOMCSV4G27XwYvXuvqzqedXy7klExfcMADLGgEMax0PKd8+uN7dpI6MTKAjZUNC+gJm3Q==",
       "dev": true,
       "dependencies": {
         "@prettier/plugin-php": "^0.19.0",
@@ -2892,14 +2947,14 @@
         "detect-indent": "^6.0.0",
         "find-config": "^1.0.0",
         "glob": "^8.0.1",
-        "html-attribute-sorter": "^0.4.2",
+        "html-attribute-sorter": "^0.4.3",
         "ignore": "^5.1.8",
         "js-beautify": "^1.14.0",
         "lodash": "^4.17.19",
-        "php-parser": "3.1.1",
+        "php-parser": "3.1.2",
         "prettier": "^2.2.0",
         "tailwindcss": "^3.1.8",
-        "vscode-oniguruma": "1.6.2",
+        "vscode-oniguruma": "1.7.0",
         "vscode-textmate": "^7.0.1",
         "xregexp": "^5.0.1",
         "yargs": "^17.3.1"
@@ -3012,18 +3067,18 @@
       }
     },
     "node_modules/blade-formatter/node_modules/ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true,
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/blade-formatter/node_modules/minimatch": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -3031,12 +3086,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/blade-formatter/node_modules/php-parser": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/php-parser/-/php-parser-3.1.1.tgz",
-      "integrity": "sha512-HUxWIWpJoGhnSVzM6nPI1O2RePd7eJKzJoL3VZr6/KUUdcHKBex2Cp7p6pWOV1WxgKI/oYgRPMywwLCP789OYA==",
-      "dev": true
     },
     "node_modules/blade-formatter/node_modules/supports-color": {
       "version": "7.2.0",
@@ -3737,9 +3786,9 @@
       "hasInstallScript": true
     },
     "node_modules/core-js-pure": {
-      "version": "3.26.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.26.1.tgz",
-      "integrity": "sha512-VVXcDpp/xJ21KdULRq/lXdLzQAtX7+37LzpyfFM973il0tWSsDEoyzG38G14AjTpK9VTfiNM9jnFauq/CpaWGQ==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.27.1.tgz",
+      "integrity": "sha512-BS2NHgwwUppfeoqOXqi08mUqS5FiZpuRuJJpKsaME7kJz0xxuk0xkhDdfMIlP/zLa80krBqss1LtD7f889heAw==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -5479,9 +5528,9 @@
       "dev": true
     },
     "node_modules/html-attribute-sorter": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/html-attribute-sorter/-/html-attribute-sorter-0.4.2.tgz",
-      "integrity": "sha512-WjAaUWPuqXxddyQ5M4vqDHG8tcO+ajTnz03GNwmTsTyGdg9dJqoswwHyniK5ygitgXxqBYIE4T88/edWkl7wMQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/html-attribute-sorter/-/html-attribute-sorter-0.4.3.tgz",
+      "integrity": "sha512-HWSvaXJki44tg0uR1t+j5pRdUVpNiZcJaoB/PFhss/YoAw9cxUDLCpIBbLWQmKjBQfWk91P6LaRnredEyabrDw==",
       "dev": true,
       "engines": {
         "node": ">= 12.0.0"
@@ -8133,9 +8182,9 @@
       }
     },
     "node_modules/js-beautify/node_modules/minimatch": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -10266,9 +10315,9 @@
       }
     },
     "node_modules/prettier-plugin-organize-imports": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.0.tgz",
-      "integrity": "sha512-jeZ13YVKgXYCzkuwnoR6saKxJmdRYWMxS2G/su1V3qDWqTo1Q5iSoTblBxsXXAmomXfPqa/uA7YCK0/S86KLOQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.1.tgz",
+      "integrity": "sha512-bty7C2Ecard5EOXirtzeCAqj4FU4epeuWrQt/Z+sh8UVEpBlBZ3m3KNPz2kFu7KgRTQx/C9o4/TdquPD1jOqjQ==",
       "dev": true,
       "peerDependencies": {
         "@volar/vue-language-plugin-pug": "^1.0.4",
@@ -10299,9 +10348,9 @@
       }
     },
     "node_modules/prettier-plugin-svelte": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-2.8.0.tgz",
-      "integrity": "sha512-QlXv/U3bUszks3XYDPsk1fsaQC+fo2lshwKbcbO+lrSVdJ+40mB1BfL8OCAk1W9y4pJxpqO/4gqm6NtF3zNGCw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-2.9.0.tgz",
+      "integrity": "sha512-3doBi5NO4IVgaNPtwewvrgPpqAcvNv0NwJNflr76PIGgi9nf1oguQV1Hpdm9TI2ALIQVn/9iIwLpBO5UcD2Jiw==",
       "dev": true,
       "peerDependencies": {
         "prettier": "^1.16.4 || ^2.0.0",
@@ -11630,9 +11679,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "3.53.1",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.53.1.tgz",
-      "integrity": "sha512-Q4/hHkktZogGhN5iqxqSi9sjEVoe/NbIxX4hXEHoasTxj+TxEQVAq66LnDMdAZxjmsodkoI5F3slqsS68U7FNw==",
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.55.0.tgz",
+      "integrity": "sha512-uGu2FVMlOuey4JoKHKrpZFkoYyj0VLjJdz47zX5+gVK5odxHM40RVhar9/iK2YFRVxvfg9FkhfVlR0sjeIrOiA==",
       "dev": true,
       "engines": {
         "node": ">= 8"
@@ -12316,15 +12365,15 @@
       }
     },
     "node_modules/vscode-oniguruma": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
-      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
       "dev": true
     },
     "node_modules/vscode-textmate": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-7.0.3.tgz",
-      "integrity": "sha512-OkE/mYm1h5ZX9IEKeKR/2zKDt2SzYyIfTEOVFX4QhA+B3BPROvNEmDDXvBThz3qknKO3Cy/VVb8/sx1UlqP/Xw==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-7.0.4.tgz",
+      "integrity": "sha512-9hJp0xL7HW1Q5OgGe03NACo7yiCTMEk3WU/rtKXUbncLtdg6rVVNJnHwD88UhbIYU2KoxY0Dih0x+kIsmUKn2A==",
       "dev": true
     },
     "node_modules/w3c-hr-time": {
@@ -13103,13 +13152,13 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.20.1.tgz",
-      "integrity": "sha512-CGulbEDcg/ND1Im7fUNRZdGXmX2MTWVVZacQi/6DiKE5HNwZ3aVTm5PV4lO8HHz0B2h8WQyvKKjbX5XgTtydsg==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.20.7.tgz",
+      "integrity": "sha512-jr9lCZ4RbRQmCR28Q8U8Fu49zvFqLxTY9AMOUz+iyMohMoAgpEcVxY+wJNay99oXOpOcCTODkk70NDN2aaJEeg==",
       "dev": true,
       "requires": {
         "core-js-pure": "^3.25.1",
-        "regenerator-runtime": "^0.13.10"
+        "regenerator-runtime": "^0.13.11"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -13911,9 +13960,9 @@
       }
     },
     "@shopify/prettier-plugin-liquid": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@shopify/prettier-plugin-liquid/-/prettier-plugin-liquid-0.4.3.tgz",
-      "integrity": "sha512-WCs7OEWvsgEdowP095DSFfCSQQedLNtppZPEK7pXINQ7WaKlmJUgATzxggTihf5wi9LyhJZdJmvnjVw6fxE+tA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@shopify/prettier-plugin-liquid/-/prettier-plugin-liquid-1.0.3.tgz",
+      "integrity": "sha512-rKrXXaxz0X8r2pep21AA2ssAYKmbiy7qPg/4cyo/ZXSsUFiGhzzzkxw7WXKFkdL/8zxv7SSm3+d1poiPoJvsTA==",
       "dev": true,
       "requires": {
         "html-styles": "^1.0.0",
@@ -13922,12 +13971,12 @@
       }
     },
     "@shufo/prettier-plugin-blade": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@shufo/prettier-plugin-blade/-/prettier-plugin-blade-1.8.0.tgz",
-      "integrity": "sha512-inWakYel77plbfWcFlA5WQO78k4TgAh0IqPF+XeGulGZiuqDg7FtUqL3ZaHMGMcBfV805YVfRM7WqtfOQ7PPVQ==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@shufo/prettier-plugin-blade/-/prettier-plugin-blade-1.8.4.tgz",
+      "integrity": "sha512-mzkQODvsnomJSXTQGeGvRCn1F0M6SLY2De89mdVIpp17w3PdUWWLweextmmm++k6BVUx0Ok+kUqePSG9NceKXg==",
       "dev": true,
       "requires": {
-        "blade-formatter": "^1.31.0",
+        "blade-formatter": "^1.32.3",
         "prettier": "^2.6.2",
         "synckit": "^0.8.4"
       },
@@ -14356,9 +14405,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
-      "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -14836,9 +14885,9 @@
       "dev": true
     },
     "blade-formatter": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/blade-formatter/-/blade-formatter-1.31.0.tgz",
-      "integrity": "sha512-PU5tlHoydJ7HWCdwaXRvdAxHdIraN63abIteGKZujqW3YzHzOkk2H7t3jFjz682mlBsbmjBjjcsguiyd0UTZHg==",
+      "version": "1.32.3",
+      "resolved": "https://registry.npmjs.org/blade-formatter/-/blade-formatter-1.32.3.tgz",
+      "integrity": "sha512-rVBOEooGBYjZ60eODVOMCSV4G27XwYvXuvqzqedXy7klExfcMADLGgEMax0PKd8+uN7dpI6MTKAjZUNC+gJm3Q==",
       "dev": true,
       "requires": {
         "@prettier/plugin-php": "^0.19.0",
@@ -14850,14 +14899,14 @@
         "detect-indent": "^6.0.0",
         "find-config": "^1.0.0",
         "glob": "^8.0.1",
-        "html-attribute-sorter": "^0.4.2",
+        "html-attribute-sorter": "^0.4.3",
         "ignore": "^5.1.8",
         "js-beautify": "^1.14.0",
         "lodash": "^4.17.19",
-        "php-parser": "3.1.1",
+        "php-parser": "3.1.2",
         "prettier": "^2.2.0",
         "tailwindcss": "^3.1.8",
-        "vscode-oniguruma": "1.6.2",
+        "vscode-oniguruma": "1.7.0",
         "vscode-textmate": "^7.0.1",
         "xregexp": "^5.0.1",
         "yargs": "^17.3.1"
@@ -14937,25 +14986,19 @@
           "dev": true
         },
         "ignore": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+          "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
           "dev": true
         },
         "minimatch": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+          "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
-        },
-        "php-parser": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/php-parser/-/php-parser-3.1.1.tgz",
-          "integrity": "sha512-HUxWIWpJoGhnSVzM6nPI1O2RePd7eJKzJoL3VZr6/KUUdcHKBex2Cp7p6pWOV1WxgKI/oYgRPMywwLCP789OYA==",
-          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
@@ -15499,9 +15542,9 @@
       "dev": true
     },
     "core-js-pure": {
-      "version": "3.26.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.26.1.tgz",
-      "integrity": "sha512-VVXcDpp/xJ21KdULRq/lXdLzQAtX7+37LzpyfFM973il0tWSsDEoyzG38G14AjTpK9VTfiNM9jnFauq/CpaWGQ==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.27.1.tgz",
+      "integrity": "sha512-BS2NHgwwUppfeoqOXqi08mUqS5FiZpuRuJJpKsaME7kJz0xxuk0xkhDdfMIlP/zLa80krBqss1LtD7f889heAw==",
       "dev": true
     },
     "cosmiconfig": {
@@ -16737,9 +16780,9 @@
       "dev": true
     },
     "html-attribute-sorter": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/html-attribute-sorter/-/html-attribute-sorter-0.4.2.tgz",
-      "integrity": "sha512-WjAaUWPuqXxddyQ5M4vqDHG8tcO+ajTnz03GNwmTsTyGdg9dJqoswwHyniK5ygitgXxqBYIE4T88/edWkl7wMQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/html-attribute-sorter/-/html-attribute-sorter-0.4.3.tgz",
+      "integrity": "sha512-HWSvaXJki44tg0uR1t+j5pRdUVpNiZcJaoB/PFhss/YoAw9cxUDLCpIBbLWQmKjBQfWk91P6LaRnredEyabrDw==",
       "dev": true
     },
     "html-encoding-sniffer": {
@@ -18731,9 +18774,9 @@
           }
         },
         "minimatch": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+          "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
@@ -20209,9 +20252,9 @@
       "requires": {}
     },
     "prettier-plugin-organize-imports": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.0.tgz",
-      "integrity": "sha512-jeZ13YVKgXYCzkuwnoR6saKxJmdRYWMxS2G/su1V3qDWqTo1Q5iSoTblBxsXXAmomXfPqa/uA7YCK0/S86KLOQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.1.tgz",
+      "integrity": "sha512-bty7C2Ecard5EOXirtzeCAqj4FU4epeuWrQt/Z+sh8UVEpBlBZ3m3KNPz2kFu7KgRTQx/C9o4/TdquPD1jOqjQ==",
       "dev": true,
       "requires": {}
     },
@@ -20226,9 +20269,9 @@
       }
     },
     "prettier-plugin-svelte": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-2.8.0.tgz",
-      "integrity": "sha512-QlXv/U3bUszks3XYDPsk1fsaQC+fo2lshwKbcbO+lrSVdJ+40mB1BfL8OCAk1W9y4pJxpqO/4gqm6NtF3zNGCw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-2.9.0.tgz",
+      "integrity": "sha512-3doBi5NO4IVgaNPtwewvrgPpqAcvNv0NwJNflr76PIGgi9nf1oguQV1Hpdm9TI2ALIQVn/9iIwLpBO5UcD2Jiw==",
       "dev": true,
       "requires": {}
     },
@@ -21280,9 +21323,9 @@
       "dev": true
     },
     "svelte": {
-      "version": "3.53.1",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.53.1.tgz",
-      "integrity": "sha512-Q4/hHkktZogGhN5iqxqSi9sjEVoe/NbIxX4hXEHoasTxj+TxEQVAq66LnDMdAZxjmsodkoI5F3slqsS68U7FNw==",
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.55.0.tgz",
+      "integrity": "sha512-uGu2FVMlOuey4JoKHKrpZFkoYyj0VLjJdz47zX5+gVK5odxHM40RVhar9/iK2YFRVxvfg9FkhfVlR0sjeIrOiA==",
       "dev": true
     },
     "symbol-tree": {
@@ -21806,15 +21849,15 @@
       }
     },
     "vscode-oniguruma": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
-      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
       "dev": true
     },
     "vscode-textmate": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-7.0.3.tgz",
-      "integrity": "sha512-OkE/mYm1h5ZX9IEKeKR/2zKDt2SzYyIfTEOVFX4QhA+B3BPROvNEmDDXvBThz3qknKO3Cy/VVb8/sx1UlqP/Xw==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-7.0.4.tgz",
+      "integrity": "sha512-9hJp0xL7HW1Q5OgGe03NACo7yiCTMEk3WU/rtKXUbncLtdg6rVVNJnHwD88UhbIYU2KoxY0Dih0x+kIsmUKn2A==",
       "dev": true
     },
     "w3c-hr-time": {

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
   "devDependencies": {
     "@prettier/plugin-php": "^0.19.2",
     "@prettier/plugin-pug": "^2.3.0",
-    "@shopify/prettier-plugin-liquid": "^1.0.0-rc.2",
-    "@shufo/prettier-plugin-blade": "^1.8.0",
+    "@shopify/prettier-plugin-liquid": "^1.0.3",
+    "@shufo/prettier-plugin-blade": "^1.8.4",
     "@tailwindcss/line-clamp": "^0.3.0",
-    "@trivago/prettier-plugin-sort-imports": "^3.3.0",
+    "@trivago/prettier-plugin-sort-imports": "^3.4.0",
     "cpy-cli": "^3.1.1",
     "esbuild": "^0.14.11",
     "escalade": "^3.1.1",
@@ -49,17 +49,75 @@
     "prettier-plugin-import-sort": "^0.0.7",
     "prettier-plugin-jsdoc": "^0.4.2",
     "prettier-plugin-organize-attributes": "^0.0.5",
-    "prettier-plugin-organize-imports": "^3.1.0",
+    "prettier-plugin-organize-imports": "^3.2.1",
     "prettier-plugin-style-order": "^0.2.2",
-    "prettier-plugin-svelte": "^2.7.0",
+    "prettier-plugin-svelte": "^2.9.0",
     "prettier-plugin-twig-melody": "^0.4.6",
     "recast": "^0.20.5",
     "rimraf": "^3.0.2",
-    "svelte": "^3.46.4",
+    "svelte": "^3.55.0",
     "tailwindcss": "^3.0.23"
   },
   "peerDependencies": {
-    "prettier": ">=2.2.0"
+    "@prettier/plugin-php": "*",
+    "@prettier/plugin-pug": "*",
+    "@shopify/prettier-plugin-liquid": "*",
+    "@shufo/prettier-plugin-blade": "*",
+    "@trivago/prettier-plugin-sort-imports": "*",
+    "prettier": ">=2.2.0",
+    "prettier-plugin-astro": "*",
+    "prettier-plugin-css-order": "*",
+    "prettier-plugin-import-sort": "*",
+    "prettier-plugin-jsdoc": "*",
+    "prettier-plugin-organize-attributes": "*",
+    "prettier-plugin-organize-imports": "*",
+    "prettier-plugin-style-order": "*",
+    "prettier-plugin-svelte": "*",
+    "prettier-plugin-twig-melody": "*"
+  },
+  "peerDependenciesMeta": {
+    "@prettier/plugin-php": {
+      "optional": true
+    },
+    "@prettier/plugin-pug": {
+      "optional": true
+    },
+    "@shopify/prettier-plugin-liquid": {
+      "optional": true
+    },
+    "@shufo/prettier-plugin-blade": {
+      "optional": true
+    },
+    "@trivago/prettier-plugin-sort-imports": {
+      "optional": true
+    },
+    "prettier-plugin-astro": {
+      "optional": true
+    },
+    "prettier-plugin-css-order": {
+      "optional": true
+    },
+    "prettier-plugin-import-sort": {
+      "optional": true
+    },
+    "prettier-plugin-jsdoc": {
+      "optional": true
+    },
+    "prettier-plugin-organize-attributes": {
+      "optional": true
+    },
+    "prettier-plugin-organize-imports": {
+      "optional": true
+    },
+    "prettier-plugin-style-order": {
+      "optional": true
+    },
+    "prettier-plugin-svelte": {
+      "optional": true
+    },
+    "prettier-plugin-twig-melody": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=12.17.0"


### PR DESCRIPTION
Fixes #112 

I tested it by publishing it to a private npm registry.
You can test it for yourself (the yarn cache is checked into the repo): https://github.com/notpeelz/bug-repro-prettier-tw-sort-imports/tree/fixed