### PR TITLE
Fix Glimmer Concatenation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Don't sort classes in Glimmer `concat` helper.
 
 ## [0.2.2] - 2023-01-24
+
+### Fixed
 
 - Add prettier plugins to peer dependencies ([#114](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/114))
 - Traverse await expression blocks in Svelte ([#118](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/118))

--- a/src/index.js
+++ b/src/index.js
@@ -340,9 +340,11 @@ function transformGlimmer(ast, { env }) {
         return
       }
 
+      const isConcat = parent.type === 'SubExpression' && parent.path.original === 'concat';
+
       node.value = sortClasses(node.value, {
         env,
-        ignoreLast: parent.type === 'SubExpression' && !/[^\S\r\n]/.test(node.value.at(-1)),
+        ignoreLast: isConcat && !/[^\S\r\n]/.test(node.value.at(-1)),
       })
     },
   })

--- a/src/index.js
+++ b/src/index.js
@@ -344,7 +344,7 @@ function transformGlimmer(ast, { env }) {
 
       node.value = sortClasses(node.value, {
         env,
-        ignoreLast: isConcat && !/[^\S\r\n]/.test(node.value.at(-1)),
+        ignoreLast: isConcat && !/[^\S\r\n]$/.test(node.value),
       })
     },
   })

--- a/src/index.js
+++ b/src/index.js
@@ -340,7 +340,10 @@ function transformGlimmer(ast, { env }) {
         return
       }
 
-      node.value = sortClasses(node.value, { env })
+      node.value = sortClasses(node.value, {
+        env,
+        ignoreLast: parent.type === 'SubExpression' && !/[^\S\r\n]/.test(node.value.at(-1)),
+      })
     },
   })
 }

--- a/tests/test.js
+++ b/tests/test.js
@@ -168,6 +168,10 @@ let glimmer = [
     `<div class='{{if @isTrue (concat "border-l-4 border " @borderColor)}}'></div>`,
     `<div class='{{if @isTrue (concat "border border-l-4 " @borderColor)}}'></div>`,
   ],
+  [
+    `<div class='{{if @isTrue (nope "border-l-4 border-" @borderColor)}}'></div>`,
+    `<div class='{{if @isTrue (nope "border- border-l-4" @borderColor)}}'></div>`,
+  ],
 ]
 
 let tests = {

--- a/tests/test.js
+++ b/tests/test.js
@@ -159,6 +159,15 @@ let glimmer = [
   t`<div class></div>`,
   t`<div class=''></div>`,
   t`{{link 'Some page' href=person.url class='${no}'}}`,
+  t`<div class='{{if @isTrue (concat "border-l-4 border-" @borderColor)}}'></div>`,
+  [
+    `<div class='{{if @isTrue (concat "border-opacity-30 border-l-4 border-" @borderColor)}}'></div>`,
+    `<div class='{{if @isTrue (concat "border-l-4 border-opacity-30 border-" @borderColor)}}'></div>`,
+  ],
+  [
+    `<div class='{{if @isTrue (concat "border-l-4 border " @borderColor)}}'></div>`,
+    `<div class='{{if @isTrue (concat "border border-l-4 " @borderColor)}}'></div>`,
+  ],
 ]
 
 let tests = {


### PR DESCRIPTION
Glimmer supports concatenation via the `(concat)` helper.

The plugin is currently incorrectly breaking up the concatenation

I first added a failing test showing the issue.

Use ignoreLast in a Glimmer StringLiteral if the parent is a SubExpression (meaning helper) and the last character of the node value is not whitespace

Meaning `(concat "border-l-blue border-" @color)` does not get sorted

While `(concat "border-l-blue border ")` does get sorted