### PR TITLE
Support tailwind-react-native-classnames

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -483,6 +483,29 @@ function transformJavaScript(ast, { env }) {
         }
       }
     },
+    TaggedTemplateExpression(node) {
+      if (node.tag.type === 'Identifier' && ['tw', 'twrnc'].includes(node.tag.name)) {
+        sortTemplateLiteral(node.quasi, { env })
+      }
+    },
+    CallExpression(node) {
+      if (node.callee.type === 'MemberExpression') {
+        if (
+          node.callee.object.type === 'Identifier' &&
+          ['tw', 'twrnc'].includes(node.callee.object.name) &&
+          node.callee.property.type === 'Identifier' &&
+          node.callee.property.name === 'style'
+        ) {
+          for (let i = 0; i < node.arguments.length; i++) {
+            if (isStringLiteral(node.arguments[i])) {
+              sortStringLiteral(node.arguments[i], { env })
+            } else if (node.arguments[i].type === 'TemplateLiteral') {
+              sortTemplateLiteral(node.arguments[i], { env })
+            }
+          }
+        }
+      }
+    },
   })
 }
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -104,6 +104,14 @@ let javascript = [
     `;<div class={\`sm:p-0 p-0 \${someVar}sm:block md:inline flex\`} />`,
     `;<div class={\`p-0 sm:p-0 \${someVar}sm:block flex md:inline\`} />`,
   ],
+  [
+    `;tw\`sm:p-0 p-0 \${someVar}sm:block md:inline flex\``,
+    `;tw\`p-0 sm:p-0 \${someVar}sm:block flex md:inline\``,
+  ],
+  [
+    `;tw.style("sm:p-0 p-0", { otherObject: 'true' }, \`\${someVar}sm:block md:inline flex\`)`,
+    `;tw.style("p-0 sm:p-0", { otherObject: 'true' }, \`\${someVar}sm:block flex md:inline\`)`,
+  ]
 ]
 javascript = javascript.concat(
   javascript.map((test) => test.map((t) => t.replace(/class/g, 'className')))


### PR DESCRIPTION
I use the excellent package [tailwind-react-native-classnames](https://github.com/jaredh159/tailwind-react-native-classnames) to build styles in a react-native app using tailwind.

I recently discovered prettier-plugin-tailwindcss, and I've found it to be extremely helpful. I want to be able to use it in my react-native project as well.

I'm happy to take feedback on how we can make this as reasonably generic as possible, and possibly non-specific to the package above.

For now I've targeted the template literals `tw` and `twrnc`:

```ts
tw`p-0 sm:p-0`
twrnc`p-0 sm:p-0`
```

And the same for any string or template literal for the `.style` method:

```ts
tw.style("p-0 sm:p-0")
twrnc.style("p-0 sm:p-0")
```

There's probably more sophisticated cases which could be caught, but I think this covers most use-cases.