### PR TITLE
Ianvs prettier plugin sort imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Don't sort classes in Glimmer `concat` helper ([#119](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/119))
+- Add support for `@ianvs/prettier-plugin-sort-imports` ([#122](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/122))
 
 ## [0.2.2] - 2023-01-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Don't sort classes in Glimmer `concat` helper.
+- Don't sort classes in Glimmer `concat` helper ([#119](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/119))
 
 ## [0.2.2] - 2023-01-24
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This plugin uses Prettier APIs that can only be used by one plugin at a time, ma
 - `@prettier/plugin-php`
 - `@prettier/plugin-pug`
 - `@shopify/prettier-plugin-liquid`
+- `@ianvs/prettier-plugin-sort-imports`
 - `@trivago/prettier-plugin-sort-imports`
 - `prettier-plugin-astro`
 - `prettier-plugin-css-order`

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.2",
       "license": "MIT",
       "devDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "^3.7.0",
         "@prettier/plugin-php": "^0.19.2",
         "@prettier/plugin-pug": "^2.3.0",
         "@shopify/prettier-plugin-liquid": "^1.0.3",
@@ -45,6 +46,7 @@
         "node": ">=12.17.0"
       },
       "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
         "@prettier/plugin-php": "*",
         "@prettier/plugin-pug": "*",
         "@shopify/prettier-plugin-liquid": "*",
@@ -62,6 +64,9 @@
         "prettier-plugin-twig-melody": "*"
       },
       "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
         "@prettier/plugin-php": {
           "optional": true
         },
@@ -868,6 +873,31 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@ianvs/prettier-plugin-sort-imports": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@ianvs/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-3.7.1.tgz",
+      "integrity": "sha512-XDnBUUruJY9KgNd7T2ZHnVPWo5B9NzVDCLEMm7HjXTA3rTtMg5Q46gYRjLvampDXSmN8+icu54aRE3IIT8U+1w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.17.7",
+        "@babel/generator": "^7.17.7",
+        "@babel/parser": "^7.17.7",
+        "@babel/traverse": "^7.17.3",
+        "@babel/types": "^7.17.0",
+        "javascript-natural-sort": "0.7.1",
+        "lodash.clone": "^4.5.0",
+        "lodash.isequal": "^4.5.0"
+      },
+      "peerDependencies": {
+        "@vue/compiler-sfc": ">=3.0.0",
+        "prettier": "2.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/compiler-sfc": {
+          "optional": true
+        }
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -8439,6 +8469,18 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.clone": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "integrity": "sha512-GhrVeweiTD6uTmmn5hV/lzgCQhccwReIVRLHp7LT4SopOjqEZ5BbX8b5WWEtAKasjmy8hR7ZPwsYlxRCku5odg==",
+      "dev": true
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "dev": true
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -13226,6 +13268,22 @@
       "integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
       "dev": true,
       "optional": true
+    },
+    "@ianvs/prettier-plugin-sort-imports": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@ianvs/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-3.7.1.tgz",
+      "integrity": "sha512-XDnBUUruJY9KgNd7T2ZHnVPWo5B9NzVDCLEMm7HjXTA3rTtMg5Q46gYRjLvampDXSmN8+icu54aRE3IIT8U+1w==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.17.7",
+        "@babel/generator": "^7.17.7",
+        "@babel/parser": "^7.17.7",
+        "@babel/traverse": "^7.17.3",
+        "@babel/types": "^7.17.0",
+        "javascript-natural-sort": "0.7.1",
+        "lodash.clone": "^4.5.0",
+        "lodash.isequal": "^4.5.0"
+      }
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -18959,6 +19017,18 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "lodash.clone": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "integrity": "sha512-GhrVeweiTD6uTmmn5hV/lzgCQhccwReIVRLHp7LT4SopOjqEZ5BbX8b5WWEtAKasjmy8hR7ZPwsYlxRCku5odg==",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
       "dev": true
     },
     "loose-envify": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "format": "prettier \"src/**/*.js\" \"scripts/**/*.js\" \"tests/test.js\" --write --print-width 100 --single-quote --no-semi --plugin-search-dir ./tests"
   },
   "devDependencies": {
+    "@ianvs/prettier-plugin-sort-imports": "^3.7.0",
     "@prettier/plugin-php": "^0.19.2",
     "@prettier/plugin-pug": "^2.3.0",
     "@shopify/prettier-plugin-liquid": "^1.0.3",
@@ -59,6 +60,7 @@
     "tailwindcss": "^3.0.23"
   },
   "peerDependencies": {
+    "@ianvs/prettier-plugin-sort-imports": "*",
     "@prettier/plugin-php": "*",
     "@prettier/plugin-pug": "*",
     "@shopify/prettier-plugin-liquid": "*",
@@ -76,6 +78,9 @@
     "prettier-plugin-twig-melody": "*"
   },
   "peerDependenciesMeta": {
+    "@ianvs/prettier-plugin-sort-imports": {
+      "optional": true
+    },
     "@prettier/plugin-php": {
       "optional": true
     },

--- a/src/index.js
+++ b/src/index.js
@@ -857,6 +857,7 @@ function getCompatibleParser(parserFormat, options) {
 
   // Now load parsers from plugins
   let compatiblePlugins = [
+    '@ianvs/prettier-plugin-sort-imports',
     '@trivago/prettier-plugin-sort-imports',
     'prettier-plugin-organize-imports',
     '@prettier/plugin-php',

--- a/tests/plugins.test.js
+++ b/tests/plugins.test.js
@@ -55,20 +55,20 @@ let tests = [
       '@ianvs/prettier-plugin-sort-imports',
     ],
     options: {
-      importOrder: ["^@one/(.*)$", "^@two/(.*)$", "^[./]"],
+      importOrder: ["^@tailwindcss/(.*)$", "^@babel/(.*)$", "^[./]"],
       importOrderSortSpecifiers: true,
     },
     tests: {
       babel: [
         [
-          `import './three'\nimport '@two/file'\nimport '@one/file'`,
-          `import '@one/file'\nimport '@two/file'\nimport './three'`,
+          `import './i-haz-side-effects'\nimport i3 from './three'\nimport i2 from '@two/file'\nimport i1 from '@one/file'`,
+          `import './i-haz-side-effects'\nimport i1 from '@one/file'\nimport i2 from '@two/file'\nimport i3 from './three'`,
         ],
       ],
       typescript: [
         [
-          `import './three'\nimport '@two/file'\nimport '@one/file'`,
-          `import '@one/file'\nimport '@two/file'\nimport './three'`,
+          `import './i-haz-side-effects'\nimport i3 from './three'\nimport i2 from '@two/file'\nimport i1 from '@one/file'`,
+          `import './i-haz-side-effects'\nimport i1 from '@one/file'\nimport i2 from '@two/file'\nimport i3 from './three'`,
         ],
       ],
 

--- a/tests/plugins.test.js
+++ b/tests/plugins.test.js
@@ -52,6 +52,37 @@ let tests = [
   },
   {
     plugins: [
+      '@ianvs/prettier-plugin-sort-imports',
+    ],
+    options: {
+      importOrder: ["^@one/(.*)$", "^@two/(.*)$", "^[./]"],
+      importOrderSortSpecifiers: true,
+    },
+    tests: {
+      babel: [
+        [
+          `import './three'\nimport '@two/file'\nimport '@one/file'`,
+          `import '@one/file'\nimport '@two/file'\nimport './three'`,
+        ],
+      ],
+      typescript: [
+        [
+          `import './three'\nimport '@two/file'\nimport '@one/file'`,
+          `import '@one/file'\nimport '@two/file'\nimport './three'`,
+        ],
+      ],
+
+      // This plugin does not support babel-ts
+      'babel-ts': [
+        [
+          `import './three'\nimport '@two/file'\nimport '@one/file'`,
+          `import './three'\nimport '@two/file'\nimport '@one/file'`,
+        ],
+      ],
+    }
+  },
+  {
+    plugins: [
       'prettier-plugin-organize-imports',
     ],
     options: {},


### PR DESCRIPTION
I edited this in GH so commits aren't squashed, but yolo.

@ianvs/prettier-plugin-sort-imports fork has been better and preserves order of side-effect imports.