### PR TITLE
support "classNames" object expression

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -474,7 +474,7 @@ function transformJavaScript(ast, { env }) {
       if (!node.value) {
         return
       }
-      if (['class', 'className'].includes(node.name.name)) {
+      if (['class', 'className', 'classNames'].includes(node.name.name)) {
         if (isStringLiteral(node.value)) {
           sortStringLiteral(node.value, { env })
         } else if (node.value.type === 'JSXExpressionContainer') {


### PR DESCRIPTION
I'd like to be able to sort tailwind classes that are passed via an object expression to component libraries like React Mantine. I'm currently using a PNPM patch with this suggested change.

Example:

```js
<TextInput
  label="Name"
  placeholder="Please enter name"
  classNames={{
    label: "block pb-2 text-sm font-semibold text-gray-400",
    icon: "pl-3 text-gray-400",
    input:
      "mt-1 h-12 w-full rounded-xl border-gray-300   pl-11 font-bold text-gray-600 placeholder:font-medium placeholder:text-gray-400 focus:border-gray-300 focus:outline focus:outline-blue-500 focus:drop-shadow-lg",
  }}
  icon={<IconUser />}
/>
```