### PR TITLE
feat: support tw prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -492,7 +492,7 @@ function transformJavaScript(ast, { env }) {
       if (!node.value) {
         return
       }
-      if (['class', 'className'].includes(node.name.name)) {
+      if (['class', 'className', 'tw'].includes(node.name.name)) {
         if (isStringLiteral(node.value)) {
           sortStringLiteral(node.value, { env })
         } else if (node.value.type === 'JSXExpressionContainer') {


### PR DESCRIPTION
# Why  

Hey maintainers!
We are using this plugin on React Native, but in React Native we often use `tw` as `className` to pass it, we have been using patches to support it all along, If it is officially supported, it will be great.

# How 

Added the `tw` keyword to the `transformJavaScript` method. 