### PR TITLE
Load modules from nearest `tailwindcss` instance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "prettier-plugin-svelte": "^2.9.0",
         "prettier-plugin-twig-melody": "^0.4.6",
         "recast": "^0.20.5",
+        "resolve-from": "^5.0.0",
         "rimraf": "^3.0.2",
         "svelte": "^3.55.0",
         "tailwindcss": "^3.3.0"
@@ -912,15 +913,6 @@
         "js-yaml": "^3.13.1",
         "resolve-from": "^5.0.0"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3659,15 +3651,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/clear-module/node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -5670,6 +5653,15 @@
         "find-root": "^1.0.0",
         "minimatch": "^3.0.4",
         "resolve-from": "^4.0.0"
+      }
+    },
+    "node_modules/import-sort-config/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/import-sort-parser": {
@@ -10798,22 +10790,13 @@
         "node": ">=8"
       }
     },
-    "node_modules/resolve-cwd/node_modules/resolve-from": {
+    "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/resolve-url": {
@@ -13351,14 +13334,6 @@
         "get-package-type": "^0.1.0",
         "js-yaml": "^3.13.1",
         "resolve-from": "^5.0.0"
-      },
-      "dependencies": {
-        "resolve-from": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-          "dev": true
-        }
       }
     },
     "@istanbuljs/schema": {
@@ -15503,14 +15478,6 @@
       "requires": {
         "parent-module": "^2.0.0",
         "resolve-from": "^5.0.0"
-      },
-      "dependencies": {
-        "resolve-from": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-          "dev": true
-        }
       }
     },
     "cliui": {
@@ -16971,6 +16938,14 @@
         "find-root": "^1.0.0",
         "minimatch": "^3.0.4",
         "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
       }
     },
     "import-sort-parser": {
@@ -20704,20 +20679,12 @@
       "dev": true,
       "requires": {
         "resolve-from": "^5.0.0"
-      },
-      "dependencies": {
-        "resolve-from": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-          "dev": true
-        }
       }
     },
     "resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
     },
     "resolve-url": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "prettier-plugin-svelte": "^2.9.0",
     "prettier-plugin-twig-melody": "^0.4.6",
     "recast": "^0.20.5",
+    "resolve-from": "^5.0.0",
     "rimraf": "^3.0.2",
     "svelte": "^3.55.0",
     "tailwindcss": "^3.3.0"

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ import lineColumn from 'line-column'
 import jsesc from 'jsesc'
 import escalade from 'escalade/sync'
 import clearModule from 'clear-module'
+import resolveFrom from 'resolve-from'
 
 let base = getBasePlugins()
 
@@ -165,12 +166,14 @@ function createParser(parserFormat, transform) {
       }
 
       try {
-        resolveConfig = requireFrom(baseDir, 'tailwindcss/resolveConfig')
-        createContext = requireFrom(baseDir, 'tailwindcss/lib/lib/setupContextUtils').createContext
-        generateRules = requireFrom(baseDir, 'tailwindcss/lib/lib/generateRules').generateRules
+        let pkgDir = path.dirname(resolveFrom(baseDir, 'tailwindcss/package.json'))
+
+        resolveConfig = require(path.join(pkgDir, 'resolveConfig'))
+        createContext = require(path.join(pkgDir, 'lib/lib/setupContextUtils')).createContext
+        generateRules = require(path.join(pkgDir, 'lib/lib/generateRules')).generateRules
 
         // Prior to `tailwindcss@3.3.0` this won't exist so we load it last
-        loadConfig = requireFrom(baseDir, 'tailwindcss/loadConfig')
+        loadConfig = require(path.join(pkgDir, 'loadConfig'))
       } catch {}
 
       if (options.tailwindConfig) {


### PR DESCRIPTION
This PR updates the `tailwindcss` module resolution so that it won't look further up the tree after finding the first instance of `tailwindcss`