### PR TITLE
Support @apply string in JavaScript

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -561,6 +561,28 @@ function transformJavaScript(ast, { env }) {
         }
       }
     },
+
+    Literal(node) {
+      if (isStringLiteral(node) && /^\@apply\s+/.test(node.value)) {
+        sortStringLiteral(node, { env })
+      }
+    },
+
+    StringLiteral(node) {
+      if (/^\@apply\s+/.test(node.value)) {
+        sortStringLiteral(node, { env })
+      }
+    },
+
+    TemplateLiteral(node) {
+      if (
+        [node.quasis[0]?.value.raw, node.quasis[0]?.value.cooked].some(
+          (value) => /^\@apply\s+/.test(value),
+        )
+      ) {
+        sortTemplateLiteral(node, { env })
+      }
+    },
   })
 }
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -80,6 +80,13 @@ let javascript = [
     `;<div class={\`sm:p-0 p-0 \${someVar}sm:block md:inline flex\`} />`,
     `;<div class={\`p-0 sm:p-0 \${someVar}sm:block flex md:inline\`} />`,
   ],
+  t`const obj = { '@apply ${yes}': {} }`,
+  t`/* const obj = { '@apply ${no}': {} } */`,
+  t`const obj = { '@not-apply ${no}': {} }`,
+  [
+    "const obj = { '@apply sm:p-0 p-0': {} }",
+    "const obj = { '@apply p-0 sm:p-0': {} }",
+  ],
 ]
 javascript = javascript.concat(
   javascript.map((test) => test.map((t) => t.replace(/class/g, 'className'))),
@@ -188,7 +195,11 @@ let tests = {
   meriyah: javascript,
   mdx: javascript
     .filter((test) => !test.find((t) => /^\/\*/.test(t)))
-    .map((test) => test.map((t) => t.replace(/^;/, ''))),
+    .map((test) =>
+      test
+        .map((t) => t.replace(/^;/, ''))
+        .map((t) => t.replace(/^const(.*)/, '```js\nconst$1\n```')),
+    ),
   svelte: [
     t`<div class="${yes}" />`,
     t`<div class />`,


### PR DESCRIPTION
This PR implements https://github.com/tailwindlabs/tailwindcss/discussions/11095.

This adds support for any string in JavaScript that begins with `@apply`.

Example usage: adding components via plugins in `tailwind.config.cjs`

```js
const plugin = require('tailwindcss/plugin')

module.exports = {
  plugins: [
    plugin(function({ addComponents }) {
      addComponents({
        '.foo': {
          '@apply sm:p-0 p-0': {},
        },
    })
  ]
}
```