### PR TITLE
Speed up formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for `prettier-plugin-marko` ([#151](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/151))
 
+### Fixed
+
+- Speed up formatting ([#153](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/153))
+
 ## [0.2.8] - 2023-04-28
 
 ### Changed

--- a/src/compat.js
+++ b/src/compat.js
@@ -1,0 +1,108 @@
+import { loadIfExists } from './utils.js'
+
+let compatiblePlugins = [
+  '@ianvs/prettier-plugin-sort-imports',
+  '@trivago/prettier-plugin-sort-imports',
+  'prettier-plugin-organize-imports',
+  '@prettier/plugin-pug',
+  '@shopify/prettier-plugin-liquid',
+  'prettier-plugin-css-order',
+  'prettier-plugin-import-sort',
+  'prettier-plugin-jsdoc',
+  'prettier-plugin-organize-attributes',
+  'prettier-plugin-style-order',
+  'prettier-plugin-twig-melody',
+]
+
+let additionalParserPlugins = [
+  'prettier-plugin-astro',
+  'prettier-plugin-svelte',
+  'prettier-plugin-twig-melody',
+  '@prettier/plugin-pug',
+  '@shopify/prettier-plugin-liquid',
+  'prettier-plugin-marko',
+]
+
+let additionalPrinterPlugins = [
+  {
+    pkg: 'prettier-plugin-svelte',
+    formats: ['svelte-ast'],
+  },
+]
+
+// ---
+
+/** @type {Map<string, any>} */
+let parserMap = new Map()
+let isTesting = process.env.NODE_ENV === 'test'
+
+export function getCompatibleParser(base, parserFormat, options) {
+  if (parserMap.has(parserFormat) && !isTesting) {
+    return parserMap.get(parserFormat)
+  }
+
+  let parser = getFreshCompatibleParser(base, parserFormat, options)
+  parserMap.set(parserFormat, parser)
+  return parser
+}
+
+function getFreshCompatibleParser(base, parserFormat, options) {
+  if (!options.plugins) {
+    return base.parsers[parserFormat]
+  }
+
+  let parser = {
+    ...base.parsers[parserFormat],
+  }
+
+  // Now load parsers from plugins
+  for (const name of compatiblePlugins) {
+    let path = null
+
+    try {
+      path = require.resolve(name)
+    } catch (err) {
+      continue
+    }
+
+    let plugin = options.plugins.find(
+      (plugin) => plugin.name === name || plugin.name === path,
+    )
+
+    // The plugin is not loaded
+    if (!plugin) {
+      continue
+    }
+
+    Object.assign(parser, plugin.parsers[parserFormat])
+  }
+
+  return parser
+}
+
+// We need to load this plugin dynamically because it's not available by default
+// And we are not bundling it with the main Prettier plugin
+export function getAdditionalParsers() {
+  let parsers = {}
+
+  for (const pkg of additionalParserPlugins) {
+    Object.assign(parsers, loadIfExists(pkg)?.parsers ?? {})
+  }
+
+  return parsers
+}
+
+export function getAdditionalPrinters() {
+  let printers = {}
+
+  for (let { pkg, formats } of additionalPrinterPlugins) {
+    let pluginPrinters = loadIfExists(pkg)?.printers
+    for (let format of formats) {
+      if (format in pluginPrinters) {
+        printers[format] = pluginPrinters[format]
+      }
+    }
+  }
+
+  return printers
+}

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,122 @@
+import clearModule from 'clear-module'
+import escalade from 'escalade/sync'
+import * as path from 'path'
+import prettier from 'prettier'
+import resolveFrom from 'resolve-from'
+import { generateRules as generateRulesFallback } from 'tailwindcss/lib/lib/generateRules'
+import { createContext as createContextFallback } from 'tailwindcss/lib/lib/setupContextUtils'
+import loadConfigFallback from 'tailwindcss/loadConfig'
+import resolveConfigFallback from 'tailwindcss/resolveConfig'
+
+/** @type {Map<string, {context: any, generateRules: () => any, expiration: number}>} */
+let contextMap = new Map()
+
+export function getTailwindConfig(options) {
+  let key = `${options.filepath}:${options.tailwindConfig ?? ''}`
+
+  if (contextMap.has(key)) {
+    let result = contextMap.get(key)
+    if (new Date() <= result.expiration) {
+      return result
+    }
+  }
+
+  let prettierConfigPath = prettier.resolveConfigFile.sync(options.filepath)
+
+  let { resolveConfig, createContext, generateRules, tailwindConfig } =
+    getFreshTailwindConfig(options, prettierConfigPath)
+
+  let expiration = new Date()
+  expiration.setSeconds(expiration.getSeconds() + 10)
+
+  let context = createContext(resolveConfig(tailwindConfig))
+  let result = {
+    context,
+    generateRules,
+    expiration,
+  }
+
+  contextMap.set(key, result)
+
+  return result
+}
+
+function getFreshTailwindConfig(options, prettierConfigPath) {
+  let createContext = createContextFallback
+  let generateRules = generateRulesFallback
+  let resolveConfig = resolveConfigFallback
+  let loadConfig = loadConfigFallback
+  let baseDir
+  let tailwindConfigPath = '__default__'
+  let tailwindConfig = {}
+
+  if (options.tailwindConfig) {
+    baseDir = prettierConfigPath
+      ? path.dirname(prettierConfigPath)
+      : process.cwd()
+  } else {
+    baseDir = prettierConfigPath
+      ? path.dirname(prettierConfigPath)
+      : options.filepath
+      ? path.dirname(options.filepath)
+      : process.cwd()
+  }
+
+  try {
+    let pkgDir = path.dirname(resolveFrom(baseDir, 'tailwindcss/package.json'))
+
+    resolveConfig = require(path.join(pkgDir, 'resolveConfig'))
+    createContext = require(path.join(
+      pkgDir,
+      'lib/lib/setupContextUtils',
+    )).createContext
+    generateRules = require(path.join(
+      pkgDir,
+      'lib/lib/generateRules',
+    )).generateRules
+
+    // Prior to `tailwindcss@3.3.0` this won't exist so we load it last
+    loadConfig = require(path.join(pkgDir, 'loadConfig'))
+  } catch {}
+
+  if (options.tailwindConfig) {
+    tailwindConfigPath = path.resolve(baseDir, options.tailwindConfig)
+    clearModule(tailwindConfigPath)
+    const loadedConfig = loadConfig(tailwindConfigPath)
+    tailwindConfig = loadedConfig.default ?? loadedConfig
+  } else {
+    let configPath
+    try {
+      configPath = escalade(baseDir, (_dir, names) => {
+        if (names.includes('tailwind.config.js')) {
+          return 'tailwind.config.js'
+        }
+        if (names.includes('tailwind.config.cjs')) {
+          return 'tailwind.config.cjs'
+        }
+        if (names.includes('tailwind.config.mjs')) {
+          return 'tailwind.config.mjs'
+        }
+        if (names.includes('tailwind.config.ts')) {
+          return 'tailwind.config.ts'
+        }
+      })
+    } catch {}
+    if (configPath) {
+      tailwindConfigPath = configPath
+      clearModule(tailwindConfigPath)
+      const loadedConfig = loadConfig(tailwindConfigPath)
+      tailwindConfig = loadedConfig.default ?? loadedConfig
+    }
+  }
+
+  // suppress "empty content" warning
+  tailwindConfig.content = ['no-op']
+
+  return {
+    resolveConfig,
+    createContext,
+    generateRules,
+    tailwindConfig,
+  }
+}

--- a/src/expiring-map.js
+++ b/src/expiring-map.js
@@ -1,0 +1,38 @@
+/**
+ * @template K
+ * @template V
+ * @typedef {object} ExpiringMap
+ * @property {(key: K) => V | undefined} get
+ * @property {(key: K, value: V) => void} set
+ */
+
+/**
+ * @template K
+ * @template V
+ * @param {number} duration
+ * @returns {ExpiringMap<K, V>}
+ */
+export function expiringMap(duration) {
+  /** @type {Map<K, {value: V, expiration: number}>} */
+  let map = new Map()
+
+  return {
+    get(key) {
+      if (map.has(key)) {
+        let result = map.get(key)
+        if (result.expiration > new Date()) {
+          return result.value
+        }
+      }
+    },
+    set(key, value) {
+      let expiration = new Date()
+      expiration.setMilliseconds(expiration.getMilliseconds() + duration)
+
+      map.set(key, {
+        value,
+        expiration,
+      })
+    },
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,9 @@ let base = getBasePlugins()
 
 let contextMap = new Map()
 
+/** @type {Map<string, any>} */
+let parserMap = new Map()
+
 function bigSign(bigIntValue) {
   return (bigIntValue > 0n) - (bigIntValue < 0n)
 }
@@ -964,6 +967,16 @@ function getBasePlugins() {
 }
 
 function getCompatibleParser(parserFormat, options) {
+  if (parserMap.has(parserFormat)) {
+    return parserMap.get(parserFormat)
+  }
+
+  let parser = getFreshCompatibleParser(parserFormat, options)
+  parserMap.set(parserFormat, parser)
+  return parser
+}
+
+function getFreshCompatibleParser(parserFormat, options) {
   if (!options.plugins) {
     return base.parsers[parserFormat]
   }

--- a/src/index.js
+++ b/src/index.js
@@ -472,7 +472,7 @@ export const parsers = {
     : {}),
 }
 
-function transformAstro(ast, { env, changes }) {
+function transformAstro(ast, { env }) {
   if (
     ast.type === 'element' ||
     ast.type === 'custom-element' ||
@@ -492,11 +492,11 @@ function transformAstro(ast, { env, changes }) {
   }
 
   for (let child of ast.children ?? []) {
-    transformAstro(child, { env, changes })
+    transformAstro(child, { env })
   }
 }
 
-function transformMarko(ast, { env, changes }) {
+function transformMarko(ast, { env }) {
   const nodesToVisit = [ast]
   while (nodesToVisit.length > 0) {
     const currentNode = nodesToVisit.pop()
@@ -537,7 +537,7 @@ function transformMarko(ast, { env, changes }) {
   }
 }
 
-function transformMelody(ast, { env, changes }) {
+function transformMelody(ast, { env }) {
   for (let child of ast.expressions ?? []) {
     transformMelody(child, { env })
   }

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,8 @@ function createParser(parserFormat, transform) {
     },
 
     parse(text, parsers, options = {}) {
+      let { context, generateRules } = getTailwindConfig(options)
+
       let original = getCompatibleParser(base, parserFormat, options)
 
       if (original.astFormat in printers) {
@@ -39,9 +41,6 @@ function createParser(parserFormat, transform) {
       }
 
       let ast = original.parse(text, parsers, options)
-
-      let { context, generateRules } = getTailwindConfig(options)
-
       transform(ast, { env: { context, generateRules, parsers, options } })
       return ast
     },

--- a/src/index.js
+++ b/src/index.js
@@ -17,9 +17,6 @@ import * as recast from 'recast'
 
 let base = getBasePlugins()
 
-/** @type {Map<string, any>} */
-let parserMap = new Map()
-
 function createParser(parserFormat, transform) {
   return {
     ...base.parsers[parserFormat],
@@ -473,7 +470,6 @@ export const parsers = {
   ...(base.parsers['liquid-html']
     ? { 'liquid-html': createParser('liquid-html', transformLiquid) }
     : {}),
-  // ...base.parsers.blade ? { blade: createParser('blade', transformBlade) } : {},
 }
 
 function transformAstro(ast, { env, changes }) {
@@ -540,13 +536,6 @@ function transformMarko(ast, { env, changes }) {
     }
   }
 }
-
-/*
-function transformBlade(ast, { env, changes }) {
-  // Blade gets formatted on parse
-  // This means we'd have to parse the blade ourselves and figure out what's HTML and what isn't
-}
-*/
 
 function transformMelody(ast, { env, changes }) {
   for (let child of ast.expressions ?? []) {
@@ -698,7 +687,6 @@ function getBasePlugins() {
   let pug = loadIfExists('@prettier/plugin-pug')
   let liquid = loadIfExists('@shopify/prettier-plugin-liquid')
   let marko = loadIfExists('prettier-plugin-marko')
-  // let blade = loadIfExists('@shufo/prettier-plugin-blade')
 
   return {
     parsers: {
@@ -725,7 +713,6 @@ function getBasePlugins() {
       ...(pug?.parsers ?? {}),
       ...(liquid?.parsers ?? {}),
       ...(marko?.parsers ?? {}),
-      // ...(blade?.parsers ?? {}),
     },
     printers: {
       ...(svelte ? { 'svelte-ast': svelte.printers['svelte-ast'] } : {}),
@@ -733,8 +720,12 @@ function getBasePlugins() {
   }
 }
 
+/** @type {Map<string, any>} */
+let parserMap = new Map()
+let isTesting = process.env.NODE_ENV === 'test'
+
 function getCompatibleParser(parserFormat, options) {
-  if (parserMap.has(parserFormat)) {
+  if (parserMap.has(parserFormat) && !isTesting) {
     return parserMap.get(parserFormat)
   }
 
@@ -759,7 +750,6 @@ function getFreshCompatibleParser(parserFormat, options) {
     'prettier-plugin-organize-imports',
     '@prettier/plugin-pug',
     '@shopify/prettier-plugin-liquid',
-    '@shufo/prettier-plugin-blade',
     'prettier-plugin-css-order',
     'prettier-plugin-import-sort',
     'prettier-plugin-jsdoc',

--- a/src/sorting.js
+++ b/src/sorting.js
@@ -1,0 +1,99 @@
+export function bigSign(bigIntValue) {
+  return (bigIntValue > 0n) - (bigIntValue < 0n)
+}
+
+function prefixCandidate(context, selector) {
+  let prefix = context.tailwindConfig.prefix
+  return typeof prefix === 'function' ? prefix(selector) : prefix + selector
+}
+
+// Polyfill for older Tailwind CSS versions
+function getClassOrderPolyfill(classes, { env }) {
+  // A list of utilities that are used by certain Tailwind CSS utilities but
+  // that don't exist on their own. This will result in them "not existing" and
+  // sorting could be weird since you still require them in order to make the
+  // host utitlies work properly. (Thanks Biology)
+  let parasiteUtilities = new Set([
+    prefixCandidate(env.context, 'group'),
+    prefixCandidate(env.context, 'peer'),
+  ])
+
+  let classNamesWithOrder = []
+
+  for (let className of classes) {
+    let order =
+      env
+        .generateRules(new Set([className]), env.context)
+        .sort(([a], [z]) => bigSign(z - a))[0]?.[0] ?? null
+
+    if (order === null && parasiteUtilities.has(className)) {
+      // This will make sure that it is at the very beginning of the
+      // `components` layer which technically means 'before any
+      // components'.
+      order = env.context.layerOrder.components
+    }
+
+    classNamesWithOrder.push([className, order])
+  }
+
+  return classNamesWithOrder
+}
+
+export function sortClasses(
+  classStr,
+  { env, ignoreFirst = false, ignoreLast = false },
+) {
+  if (typeof classStr !== 'string' || classStr === '') {
+    return classStr
+  }
+
+  // Ignore class attributes containing `{{`, to match Prettier behaviour:
+  // https://github.com/prettier/prettier/blob/main/src/language-html/embed.js#L83-L88
+  if (classStr.includes('{{')) {
+    return classStr
+  }
+
+  let result = ''
+  let parts = classStr.split(/(\s+)/)
+  let classes = parts.filter((_, i) => i % 2 === 0)
+  let whitespace = parts.filter((_, i) => i % 2 !== 0)
+
+  if (classes[classes.length - 1] === '') {
+    classes.pop()
+  }
+
+  let prefix = ''
+  if (ignoreFirst) {
+    prefix = `${classes.shift() ?? ''}${whitespace.shift() ?? ''}`
+  }
+
+  let suffix = ''
+  if (ignoreLast) {
+    suffix = `${whitespace.pop() ?? ''}${classes.pop() ?? ''}`
+  }
+
+  classes = sortClassList(classes, { env })
+
+  for (let i = 0; i < classes.length; i++) {
+    result += `${classes[i]}${whitespace[i] ?? ''}`
+  }
+
+  return prefix + result + suffix
+}
+
+export function sortClassList(classList, { env }) {
+  let classNamesWithOrder = env.context.getClassOrder
+    ? env.context.getClassOrder(classList)
+    : getClassOrderPolyfill(classList, { env })
+
+  return classNamesWithOrder
+    .sort(([, a], [, z]) => {
+      if (a === z) return 0
+      // if (a === null) return options.unknownClassPosition === 'start' ? -1 : 1
+      // if (z === null) return options.unknownClassPosition === 'start' ? 1 : -1
+      if (a === null) return -1
+      if (z === null) return 1
+      return bigSign(a - z)
+    })
+    .map(([className]) => className)
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,40 @@
+// For loading prettier plugins only if they exist
+export function loadIfExists(name) {
+  try {
+    if (require.resolve(name)) {
+      return require(name)
+    }
+  } catch (e) {
+    return null
+  }
+}
+
+// https://lihautan.com/manipulating-ast-with-javascript/
+export function visit(ast, callbackMap) {
+  function _visit(node, parent, key, index, meta = {}) {
+    if (typeof callbackMap === 'function') {
+      if (callbackMap(node, parent, key, index, meta) === false) {
+        return
+      }
+    } else if (node.type in callbackMap) {
+      if (callbackMap[node.type](node, parent, key, index, meta) === false) {
+        return
+      }
+    }
+
+    const keys = Object.keys(node)
+    for (let i = 0; i < keys.length; i++) {
+      const child = node[keys[i]]
+      if (Array.isArray(child)) {
+        for (let j = 0; j < child.length; j++) {
+          if (child[j] !== null) {
+            _visit(child[j], node, keys[i], j, { ...meta })
+          }
+        }
+      } else if (typeof child?.type === 'string') {
+        _visit(child, node, keys[i], i, { ...meta })
+      }
+    }
+  }
+  _visit(ast)
+}

--- a/tests/plugins.test.js
+++ b/tests/plugins.test.js
@@ -225,6 +225,10 @@ let tests = [
   },
 ]
 
+// Disable pug printer -- it produces noisy test output
+let pug = require('@prettier/plugin-pug')
+pug.logger.level = 'off'
+
 for (const group of tests) {
   let name = group.plugins.join(', ')
 


### PR DESCRIPTION
The way this plugin works currently is that for every invocation of `parse` by Prettier we:
- Load compatible plugins (if available)
- Locate the Tailwind config
- Load the config
- Create a context (if the config hasn't changed)

However, in plugins like Svelte or Vue that handle mixed languages, `parse` is called for every single JS or TypeScript expression. When there's a lot of them all of the above happens once for every single expression in a Svelte or Vue file 😱. Doing this once or twice total isn't a big deal — but if your file has hundreds of expressions, dynamic attributes, etc… this time adds up.

With this change we now do this at most once per source file per 5s interval (this is subject to change). The time interval lets us handle changes to the Tailwind CSS config without performing expensive operations like object hashing while also caching the config and everything associated with it.

When plugins are involved the time and memory savings can be fairly significant. I've seen the time drop from 15s to 3.5s for a Svelte file with 1,000 expressions (around 3s of that is the baseline with just the Svelte plugin). The memory savings in that case dropped from 3.5GB across 3 files to around 350-ish MB.

Fixes #148

This might also fix the issues people have seen in Vue and Next projects but not yet 100% certain.