### PR TITLE
Do not split classes by non-ASCII whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Don't move partial classes inside Liquid script attributes ([#164](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/164))
+- Do not split classes by non-ASCII whitespace ([#166](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/166))
 
 ## [0.3.0] - 2023-05-15
 

--- a/src/sorting.js
+++ b/src/sorting.js
@@ -54,7 +54,7 @@ export function sortClasses(
   }
 
   let result = ''
-  let parts = classStr.split(/(\s+)/)
+  let parts = classStr.split(/([\t\r\f\n ]+)/)
   let classes = parts.filter((_, i) => i % 2 === 0)
   let whitespace = parts.filter((_, i) => i % 2 !== 0)
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -83,6 +83,10 @@ let javascript = [
     `;<div class={\`sm:p-0 p-0 \${someVar}sm:block md:inline flex\`} />`,
     `;<div class={\`p-0 sm:p-0 \${someVar}sm:block flex md:inline\`} />`,
   ],
+  [
+    `;<div class="block px-1\u3000py-2" />`,
+    `;<div class="px-1\u3000py-2 block" />`,
+  ],
 ]
 javascript = javascript.concat(
   javascript.map((test) => test.map((t) => t.replace(/class/g, 'className'))),


### PR DESCRIPTION
Hello, recently applying `prettier-plugin-tailwindcss` broke our styling :sob: so here is a fix.

## Problem

According to the [web standard](https://dom.spec.whatwg.org/#concept-getelementsbyclassname), HTML's `class` attribute is split by ASCII whitespace into a set of classes. In other words, non-ASCII whitespace characters are not class separators.

For example, `px-1　py-2` is one class (notice that the spece in between is a U+3000), not two classes (`px-1` and `py-2`).

However, this plugin wrongly treats non-ASCII whitespace as a class separator, which may lead to unintended change of meaning of code.

The concrete scenario is that, when I newly applied `prettier-plugin-tailwindcss` to our project there was code like:

```jsx
<div className="relative w-full px-1[U+3000]z-10" />
```

where `px-1` and `z-10` weren't effective due to the U+3000.

After applying this plugin this turned into:

```jsx
<div className="relative z-10 w-full[U+3000]px-1" />
```

Now `z-10` revived and `w-full` went ineffective instead, which led to unwanted styling change.

## Solution

This PR fixes the problem by treating only ASCII whitespace as separators.

## Note

Of course use of `U+3000` is a mistake and should have been prevented by some sort of linting. However, [eslint-plugin-tailwindcss had the same issue](https://github.com/francoismassart/eslint-plugin-tailwindcss/issues/245) :cry:
