### PR TITLE
Setup release workflows

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,55 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  CI: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    permissions:
+      contents: write # for softprops/action-gh-release to create GitHub release
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - run: git fetch --tags -f
+
+      - name: Resolve version
+        id: vars
+        run: |
+          echo "TAG_NAME=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+
+      - name: Get release notes
+        run: |
+          RELEASE_NOTES=$(npm run release-notes --silent)
+          echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
+          echo "$RELEASE_NOTES" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          tag_name: ${{ env.TAG_NAME }}
+          body: |
+            ${{ env.RELEASE_NOTES }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  CI: true
+  CACHE_PREFIX: stable
+  NODE_VERSION: 16
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Use cached node_modules
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ env.CACHE_PREFIX }}-node_modules-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build Prettier Plugin
+        run: |
+          npm run build
+
+      - name: Test
+        run: |
+          npm run test
+
+      - name: Calculate environment variables
+        run: |
+          echo "RELEASE_CHANNEL=$(npm run release-channel --silent)" >> $GITHUB_ENV
+
+      - name: Publish
+        run: npm publish --tag ${{ env.RELEASE_CHANNEL }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "pretest": "node scripts/install-fixture-deps.js",
     "test": "jest",
     "prepublishOnly": "npm run build && npm test && node scripts/copy-licenses.js",
-    "format": "prettier \"src/**/*.js\" \"scripts/**/*.js\" \"tests/test.js\" --write --print-width 100 --single-quote --no-semi --plugin-search-dir ./tests"
+    "format": "prettier \"src/**/*.js\" \"scripts/**/*.js\" \"tests/test.js\" --write --print-width 100 --single-quote --no-semi --plugin-search-dir ./tests",
+    "release-channel": "node ./scripts/release-channel.js",
+    "release-notes": "node ./scripts/release-notes.js"
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^3.7.0",

--- a/scripts/release-channel.js
+++ b/scripts/release-channel.js
@@ -1,0 +1,20 @@
+// Given a version, figure out what the release channel is so that we can publish to the correct
+// channel on npm.
+//
+// E.g.:
+//
+//   1.2.3                  -> latest (default)
+//   0.0.0-insiders.ffaa88  -> insiders
+//   4.1.0-alpha.4          -> alpha
+
+let version =
+  process.argv[2] ||
+  process.env.npm_package_version ||
+  require('../package.json').version
+
+let match = /\d+\.\d+\.\d+-(.*)\.\d+/g.exec(version)
+if (match) {
+  console.log(match[1])
+} else {
+  console.log('latest')
+}

--- a/scripts/release-notes.js
+++ b/scripts/release-notes.js
@@ -1,0 +1,26 @@
+// Given a version, figure out what the release notes are so that we can use this to pre-fill the
+// relase notes on a GitHub release for the current version.
+
+let path = require('path')
+let fs = require('fs')
+
+let version =
+  process.argv[2] ||
+  process.env.npm_package_version ||
+  require('../package.json').version
+
+let changelog = fs.readFileSync(
+  path.resolve(__dirname, '..', 'CHANGELOG.md'),
+  'utf8',
+)
+let match = new RegExp(
+  `## \\[${version}\\] - (.*)\\n\\n([\\s\\S]*?)\\n(?:(?:##\\s)|(?:\\[))`,
+  'g',
+).exec(changelog)
+
+if (match) {
+  let [, , notes] = match
+  console.log(notes.trim())
+} else {
+  console.log(`Placeholder release notes for version: v${version}`)
+}


### PR DESCRIPTION
This PR adds workflows for release new versions of this plugin.

When you push a `tag` to the repo the following things will happen:

1. The `prepare-release` workflow will be executed, and this will open a draft release on GitHub for
   the current version with the release notes found in the `CHANGELOG.md` for this version.
2. Once you are happy with this draft (you can edit the contents if you want), then you can publish
   the release on GitHub.
3. This triggers a new workflow that will publish the version to `npm`.

This is the same behaviour that we have on various other repo's.
