### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ module.exports = {
   plugins: [require('prettier-plugin-tailwindcss')],
 }
 ```
+or
+```js
+// prettier.config.js (Prettier v3.x)
+module.exports = {
+  plugins: ['prettier-plugin-tailwindcss'],
+}
+```
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -4,25 +4,16 @@ A [Prettier](https://prettier.io/) plugin for Tailwind CSS v3.0+ that automatica
 
 ## Installation
 
-To get started, just install `prettier-plugin-tailwindcss` as a dev-dependency:
+To get started, install `prettier-plugin-tailwindcss` as a dev-dependency:
 
 ```sh
 npm install -D prettier prettier-plugin-tailwindcss
 ```
 
-When using Prettier v2, this plugin follows Prettier’s autoloading convention, so as long as you’ve got Prettier set up in your project, it’ll start working automatically as soon as it’s installed.
-
-_Note that plugin autoloading is not supported when using Prettier v3, or when using certain package managers with Prettier v2, such as pnpm or Yarn PnP. In this case you may need to add the plugin to your Prettier config explicitly:_
+Then add the plugin to your Prettier config:
 
 ```js
 // prettier.config.js
-module.exports = {
-  plugins: [require('prettier-plugin-tailwindcss')],
-}
-```
-or
-```js
-// prettier.config.js (Prettier v3.x)
 module.exports = {
   plugins: ['prettier-plugin-tailwindcss'],
 }


### PR DESCRIPTION
Using Prettier v3.x, this doesn't work.
```js
// prettier.config.js
module.exports = {
  plugins: [require('prettier-plugin-tailwindcss')],
}
```

This does work:
```js
// prettier.config.js (Prettier v3.x)
module.exports = {
  plugins: ['prettier-plugin-tailwindcss'],
}
```

See docs: https://prettier.io/docs/en/plugins.html