### PR TITLE
Support `class:list` directive of Astro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support sorting in Astro `class:list` ([#192](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/192))
+- Sort expressions in Astro's `class:list` attribute ([#192](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/192))
 
 ## [0.4.1] - 2023-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Added
+
+- Support sorting in Astro `class:list` ([#192](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/192))
 
 ## [0.4.1] - 2023-07-14
 

--- a/src/plugin-v2.js
+++ b/src/plugin-v2.js
@@ -569,6 +569,27 @@ function transformAstro(ast, { env, changes }) {
         attr.value = sortClasses(attr.value, {
           env,
         })
+      } else if (
+        attr.name === 'class:list' &&
+        attr.type === 'attribute' &&
+        attr.kind === 'expression'
+      ) {
+        let exprValue = attr.value
+        const { typescript: parse } = env.parsers
+        const { tokens } = parse(exprValue)
+
+        tokens.forEach((token) => {
+          if (token.type === 'String') {
+            const [rangeStart, rangeEnd] = token.range
+            const sortedPart = sortClasses(exprValue.slice(rangeStart + 1, rangeEnd - 1), {
+              env,
+            })
+
+            exprValue = `${exprValue.slice(0, rangeStart + 1)}${sortedPart}${exprValue.slice(rangeEnd - 1)}`
+          }
+        })
+
+        attr.value = exprValue
       }
     }
   }

--- a/src/plugin-v2.js
+++ b/src/plugin-v2.js
@@ -572,27 +572,10 @@ function transformAstro(ast, { env, changes }) {
       } else if (
         attr.name === 'class:list' &&
         attr.type === 'attribute' &&
-        attr.kind === 'expression'
+        attr.kind === 'expression' &&
+        typeof attr.value === 'string'
       ) {
-        let exprValue = attr.value
-        const { typescript: parse } = env.parsers
-        const { tokens } = parse(exprValue)
-
-        tokens.forEach((token) => {
-          if (
-            token.type === 'String' ||
-            (token.type === 'Template' && token.value.match(/^`[^`]+`$/) !== null)
-          ) {
-            const [rangeStart, rangeEnd] = token.range
-            const sortedPart = sortClasses(exprValue.slice(rangeStart + 1, rangeEnd - 1), {
-              env,
-            })
-
-            exprValue = `${exprValue.slice(0, rangeStart + 1)}${sortedPart}${exprValue.slice(rangeEnd - 1)}`
-          }
-        })
-
-        attr.value = exprValue
+        transformDynamicJsAttribute(attr, env)
       }
     }
   }

--- a/src/plugin-v2.js
+++ b/src/plugin-v2.js
@@ -553,7 +553,7 @@ function transformCss(ast, { env }) {
  * @param {TransformerContext} param1
  */
 function transformAstro(ast, { env, changes }) {
-  let { staticAttrs } = env.customizations
+  let { staticAttrs, dynamicAttrs } = env.customizations
 
   if (
     ast.type === 'element' ||
@@ -570,7 +570,7 @@ function transformAstro(ast, { env, changes }) {
           env,
         })
       } else if (
-        attr.name === 'class:list' &&
+        dynamicAttrs.has(attr.name) &&
         attr.type === 'attribute' &&
         attr.kind === 'expression' &&
         typeof attr.value === 'string'
@@ -903,6 +903,7 @@ export const parsers = {
     ? {
         astro: createParser('astro', transformAstro, {
           staticAttrs: ['class'],
+          dynamicAttrs: ['class:list'],
         }),
       }
     : {}),

--- a/src/plugin-v2.js
+++ b/src/plugin-v2.js
@@ -579,7 +579,10 @@ function transformAstro(ast, { env, changes }) {
         const { tokens } = parse(exprValue)
 
         tokens.forEach((token) => {
-          if (token.type === 'String') {
+          if (
+            token.type === 'String' ||
+            (token.type === 'Template' && token.value.match(/^`[^`]+`$/) !== null)
+          ) {
             const [rangeStart, rangeEnd] = token.range
             const sortedPart = sortClasses(exprValue.slice(rangeStart + 1, rangeEnd - 1), {
               env,

--- a/src/plugin-v3.js
+++ b/src/plugin-v3.js
@@ -569,6 +569,27 @@ function transformAstro(ast, { env, changes }) {
         attr.value = sortClasses(attr.value, {
           env,
         })
+      } else if (
+        attr.name === 'class:list' &&
+        attr.type === 'attribute' &&
+        attr.kind === 'expression'
+      ) {
+        let exprValue = attr.value
+        const { typescript: parse } = env.parsers
+        const { tokens } = parse(exprValue)
+
+        tokens.forEach((token) => {
+          if (token.type === 'String') {
+            const [rangeStart, rangeEnd] = token.range
+            const sortedPart = sortClasses(exprValue.slice(rangeStart + 1, rangeEnd - 1), {
+              env,
+            })
+
+            exprValue = `${exprValue.slice(0, rangeStart + 1)}${sortedPart}${exprValue.slice(rangeEnd - 1)}`
+          }
+        })
+
+        attr.value = exprValue
       }
     }
   }

--- a/src/plugin-v3.js
+++ b/src/plugin-v3.js
@@ -572,27 +572,10 @@ function transformAstro(ast, { env, changes }) {
       } else if (
         attr.name === 'class:list' &&
         attr.type === 'attribute' &&
-        attr.kind === 'expression'
+        attr.kind === 'expression' &&
+        typeof attr.value === 'string'
       ) {
-        let exprValue = attr.value
-        const { typescript: parse } = env.parsers
-        const { tokens } = parse(exprValue)
-
-        tokens.forEach((token) => {
-          if (
-            token.type === 'String' ||
-            (token.type === 'Template' && token.value.match(/^`[^`]+`$/) !== null)
-          ) {
-            const [rangeStart, rangeEnd] = token.range
-            const sortedPart = sortClasses(exprValue.slice(rangeStart + 1, rangeEnd - 1), {
-              env,
-            })
-
-            exprValue = `${exprValue.slice(0, rangeStart + 1)}${sortedPart}${exprValue.slice(rangeEnd - 1)}`
-          }
-        })
-
-        attr.value = exprValue
+        transformDynamicJsAttribute(attr, env)
       }
     }
   }

--- a/src/plugin-v3.js
+++ b/src/plugin-v3.js
@@ -553,7 +553,7 @@ function transformCss(ast, { env }) {
  * @param {TransformerContext} param1
  */
 function transformAstro(ast, { env, changes }) {
-  let { staticAttrs } = env.customizations
+  let { staticAttrs, dynamicAttrs } = env.customizations
 
   if (
     ast.type === 'element' ||
@@ -570,7 +570,7 @@ function transformAstro(ast, { env, changes }) {
           env,
         })
       } else if (
-        attr.name === 'class:list' &&
+        dynamicAttrs.has(attr.name) &&
         attr.type === 'attribute' &&
         attr.kind === 'expression' &&
         typeof attr.value === 'string'
@@ -903,6 +903,7 @@ export const parsers = {
     ? {
         astro: createParser('astro', transformAstro, {
           staticAttrs: ['class'],
+          dynamicAttrs: ['class:list'],
         }),
       }
     : {}),

--- a/src/plugin-v3.js
+++ b/src/plugin-v3.js
@@ -579,7 +579,10 @@ function transformAstro(ast, { env, changes }) {
         const { tokens } = parse(exprValue)
 
         tokens.forEach((token) => {
-          if (token.type === 'String') {
+          if (
+            token.type === 'String' ||
+            (token.type === 'Template' && token.value.match(/^`[^`]+`$/) !== null)
+          ) {
             const [rangeStart, rangeEnd] = token.range
             const sortedPart = sortClasses(exprValue.slice(rangeStart + 1, rangeEnd - 1), {
               env,

--- a/tests/plugins.test.js
+++ b/tests/plugins.test.js
@@ -296,6 +296,9 @@ import Custom from '../components/Custom.astro'
         t`<div>
   <span class:list={['${yes}', { '${yes}': '${yes}' }, new Set(['${yes}'])]}></span>
 </div>`,
+        t`<div>
+  <span class:list={[\`${yes}\`, \`\${'${yes}'}\`, \`\${\`${yes}\`}\`, \`\${\`\${'${yes}'}\`}\`]}></span>
+</div>`,
       ],
     },
   },

--- a/tests/plugins.test.js
+++ b/tests/plugins.test.js
@@ -293,6 +293,9 @@ import Custom from '../components/Custom.astro'
   <my-element class="${yes}"></my-element>
   <Custom class="${yes}" />
 </Layout>`,
+        t`<div>
+  <span class:list={['${yes}', { '${yes}': '${yes}' }, new Set(['${yes}'])]}></span>
+</div>`,
       ],
     },
   },


### PR DESCRIPTION
Hello!

I recently got to know the Astro framework and have been playing around with a practice project for the past few days.
However, when using the [`class:list` directive](https://docs.astro.build/en/reference/directives-reference/#classlist), even if the `tailwindAttributes: ['class:list']` option is set, classes are not sorted, so I opened this PR.