### PR TITLE
Update peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@shopify/prettier-plugin-liquid": "*",
     "@shufo/prettier-plugin-blade": "*",
     "@trivago/prettier-plugin-sort-imports": "*",
-    "prettier": "^2.2 || ^3.0",
+    "prettier": "^3.0",
     "prettier-plugin-astro": "*",
     "prettier-plugin-css-order": "*",
     "prettier-plugin-import-sort": "*",


### PR DESCRIPTION
This should just list Prettier v3. Not v2 as well.