### PR TITLE
Fix interop with bundled CJS dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Fix intertop with bundled CJS dependencies ([#199](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/199))
 
 ## [0.5.1] - 2023-08-10
 

--- a/build.mjs
+++ b/build.mjs
@@ -89,11 +89,7 @@ let context = await esbuild.context({
   entryPoints: [path.resolve(__dirname, './src/index.js')],
   outfile: path.resolve(__dirname, './dist/index.mjs'),
   format: 'esm',
-  plugins: [
-    patchRecast(),
-    patchDynamicRequires(),
-    copyTypes(),
-  ],
+  plugins: [patchRecast(), patchDynamicRequires(), copyTypes()],
 })
 
 await context.rebuild()

--- a/build.mjs
+++ b/build.mjs
@@ -45,9 +45,12 @@ function patchDynamicRequires() {
         // Prepend `createRequire`
         let code = [
           `import {createRequire} from 'module'`,
-          `import {dirname as __workaround__dirname__} from 'path'`,
+          `import {dirname as __global__dirname__} from 'path'`,
+
+          // CJS interop fixes
+          `const require=createRequire(import.meta.url)`,
           `const __filename=new URL(import.meta.url).pathname`,
-          `const __dirname=__workaround__dirname__(__filename)`,
+          `const __dirname=__global__dirname__(__filename)`,
         ]
 
         content = `${code.join('\n')}\n${content}`
@@ -56,13 +59,13 @@ function patchDynamicRequires() {
         // unminified version
         content = content.replace(
           `throw Error('Dynamic require of "' + x + '" is not supported');`,
-          `return createRequire(import.meta.url).apply(this, arguments);`,
+          `return require.apply(this, arguments);`,
         )
 
         // minified version
         content = content.replace(
           `throw Error('Dynamic require of "'+e+'" is not supported')`,
-          `return createRequire(import.meta.url).apply(this,arguments)`,
+          `return require.apply(this,arguments)`,
         )
 
         fs.promises.writeFile(outfile, content)

--- a/build.mjs
+++ b/build.mjs
@@ -1,7 +1,7 @@
-import esbuild from 'esbuild'
-import path from 'path'
 import fs from 'fs'
+import path from 'path'
 import { fileURLToPath } from 'url'
+import esbuild from 'esbuild'
 
 /**
  * @returns {import('esbuild').Plugin}
@@ -34,7 +34,7 @@ function patchRecast() {
  * @returns {import('esbuild').Plugin}
  */
 function patchDynamicRequires() {
-  return     {
+  return {
     name: 'patch-dynamic-requires',
     setup(build) {
       build.onEnd(async () => {
@@ -43,7 +43,11 @@ function patchDynamicRequires() {
         let content = await fs.promises.readFile(outfile)
 
         // Prepend `createRequire`
-        content = `import {createRequire} from 'module';\n${content}`
+        let code = [
+          `import {createRequire} from 'module'`,
+        ]
+
+        content = `${code.join('\n')}\n${content}`
 
         // Replace dynamic require error with createRequire
         // unminified version
@@ -81,7 +85,6 @@ function copyTypes() {
   }
 }
 
-
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 let context = await esbuild.context({
@@ -92,7 +95,7 @@ let context = await esbuild.context({
   minify: process.argv.includes('--minify'),
   entryPoints: [path.resolve(__dirname, './src/index.js')],
   outfile: path.resolve(__dirname, './dist/index.mjs'),
-  format: "esm",
+  format: 'esm',
   plugins: [
     patchRecast(),
     patchDynamicRequires(),

--- a/build.mjs
+++ b/build.mjs
@@ -33,9 +33,9 @@ function patchRecast() {
 /**
  * @returns {import('esbuild').Plugin}
  */
-function patchDynamicRequires() {
+function patchCjsInterop() {
   return {
-    name: 'patch-dynamic-requires',
+    name: 'patch-cjs-interop',
     setup(build) {
       build.onEnd(async () => {
         let outfile = './dist/index.mjs'
@@ -89,7 +89,7 @@ let context = await esbuild.context({
   entryPoints: [path.resolve(__dirname, './src/index.js')],
   outfile: path.resolve(__dirname, './dist/index.mjs'),
   format: 'esm',
-  plugins: [patchRecast(), patchDynamicRequires(), copyTypes()],
+  plugins: [patchRecast(), patchCjsInterop(), copyTypes()],
 })
 
 await context.rebuild()

--- a/build.mjs
+++ b/build.mjs
@@ -55,19 +55,6 @@ function patchDynamicRequires() {
 
         content = `${code.join('\n')}\n${content}`
 
-        // Replace dynamic require error with createRequire
-        // unminified version
-        content = content.replace(
-          `throw Error('Dynamic require of "' + x + '" is not supported');`,
-          `return require.apply(this, arguments);`,
-        )
-
-        // minified version
-        content = content.replace(
-          `throw Error('Dynamic require of "'+e+'" is not supported')`,
-          `return require.apply(this,arguments)`,
-        )
-
         fs.promises.writeFile(outfile, content)
       })
     },

--- a/build.mjs
+++ b/build.mjs
@@ -45,6 +45,9 @@ function patchDynamicRequires() {
         // Prepend `createRequire`
         let code = [
           `import {createRequire} from 'module'`,
+          `import {dirname as __workaround__dirname__} from 'path'`,
+          `const __filename=new URL(import.meta.url).pathname`,
+          `const __dirname=__workaround__dirname__(__filename)`,
         ]
 
         content = `${code.join('\n')}\n${content}`

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@shopify/prettier-plugin-liquid": "*",
         "@shufo/prettier-plugin-blade": "*",
         "@trivago/prettier-plugin-sort-imports": "*",
-        "prettier": "^2.2 || ^3.0",
+        "prettier": "^3.0",
         "prettier-plugin-astro": "*",
         "prettier-plugin-css-order": "*",
         "prettier-plugin-import-sort": "*",


### PR DESCRIPTION
We bundle several dependencies into the `dist/index.mjs` file. Previously, the build was CJS and everything "just worked" but now that it's ESM-only some top-level constants like `__filename` and `__dirname` are not defined and esbuild doesn't handle that for us :( Additionally, `require.cache` isn't passed through to `createRequire(…).cache` so we do that as well.

I think in an ideal world world we'd somehow split all bundled CJS dependencies into a separate `.cjs` file to allow everything to be handled by node itself. I'm not sure what that looks like at the moment though.

Fix for #198 (I hope 😅)