### PR TITLE
fix(types): make `tailwindFunctions` and `tailwindAttributes` optional

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -9,12 +9,12 @@ export interface PluginOptions {
   /**
    * List of custom function and tag names that contain classes.
    */
-  tailwindFunctions: string[]
+  tailwindFunctions?: string[]
 
   /**
    * List of custom attributes that contain classes.
    */
-  tailwindAttributes: string[]
+  tailwindAttributes?: string[]
 }
 
 declare module 'prettier' {


### PR DESCRIPTION
Recently stumbled upon this error, which there is already a workaround here: https://github.com/tailwindlabs/prettier-plugin-tailwindcss/issues/161#issuecomment-1555182516

It seems that in #162 these optional arguments were made necessary. See more below.

Before
```ts
export interface RawOptions {
  tailwindConfig?: string
  tailwindFunctions?: string[]
  tailwindAttributes?: string[]
}
```

After
```ts
export interface PluginOptions {
  /**
   * Path to the Tailwind config file.
   */
  tailwindConfig?: string

  /**
   * List of custom function and tag names that contain classes.
   */
  tailwindFunctions: string[]

  /**
   * List of custom attributes that contain classes.
   */
  tailwindAttributes: string[]
}
```