### PR TITLE
Fix dynamicAttrs options.js

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -67,10 +67,10 @@ export function getCustomizations(options, parser, defaults) {
   // Generate a list of dynamic attributes
   for (let attr of staticAttrs) {
     if (parser === 'vue') {
-      dynamicAttrs.add(`:${attr.name}`)
-      dynamicAttrs.add(`v-bind:${attr.name}`)
+      dynamicAttrs.add(`:${attr}`)
+      dynamicAttrs.add(`v-bind:${attr}`)
     } else if (parser === 'angular') {
-      dynamicAttrs.add(`[${attr.name}]`)
+      dynamicAttrs.add(`[${attr}]`)
     }
   }
 

--- a/tests/fixtures.test.js
+++ b/tests/fixtures.test.js
@@ -98,6 +98,7 @@ let e = dontSortMeTemplate\`sm:p-1 p-2\`;
 <template>
   <div class="p-2 sm:p-1" sortMe="p-2 sm:p-1" dontSortMe="sm:p-1 p-2"></div>
   <div :class="{ 'p-2 sm:p-1': true }"></div>
+  <div :sortMe="{ 'p-2 sm:p-1': true }"></div>
 </template>`,
   },
 ]

--- a/tests/fixtures/custom-vue/index.vue
+++ b/tests/fixtures/custom-vue/index.vue
@@ -8,4 +8,5 @@
 <template>
   <div class="sm:p-1 p-2" sortMe="sm:p-1 p-2" dontSortMe="sm:p-1 p-2"></div>
   <div :class="{'sm:p-1 p-2': true}"></div>
+  <div :sortMe="{'sm:p-1 p-2': true}"></div>
 </template>


### PR DESCRIPTION
Previously in the for loop for dynamicAttrs "attr.name" was added in the string template (which was undefined) while the required value was "attr" itself.
e.g. tailwindAttributes: ["ui"],

Before:
staticAttrs: "class,ui"
dynamicAttrs: ":class,v-bind:class,:undefined,v-bind:undefined"

After:
staticAttrs: "class,ui"
dynamicAttrs: ":class,v-bind:class,:ui,v-bind:ui"

fixes [Prettier Plugin Tailwind within :ui={...}](https://github.com/nuxt/ui/issues/776) and [[Prettier Plugin] Can't seem to get "tailwindAttributes" and/or "tailwindFunctions" to work?](https://github.com/tailwindlabs/tailwindcss/discussions/12270)