### PR TITLE
Bump bundled version of Tailwind CSS to v3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Changed
+
+- Bumped bundled version of Tailwind CSS to v3.4 ([#235](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/235))
 
 ## [0.5.9] - 2023-12-05
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "resolve-from": "^5.0.0",
         "rimraf": "^5.0.5",
         "svelte": "^4.2.8",
-        "tailwindcss": "^3.3.6"
+        "tailwindcss": "^3.4.0"
       },
       "engines": {
         "node": ">=14.21.3"
@@ -8738,9 +8738,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.6.tgz",
-      "integrity": "sha512-AKjF7qbbLvLaPieoKeTjG1+FyNZT6KaJMJPFeQyLfIp7l82ggH1fbHJSsYIvnbTFQOlkh+gBYpyby5GT1LIdLw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.0.tgz",
+      "integrity": "sha512-VigzymniH77knD1dryXbyxR+ePHihHociZbXnLZHUyzf2MMs2ZVqlUrZ3FvpXP8pno9JzmILt1sZPD19M3IxtA==",
       "dev": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "resolve-from": "^5.0.0",
     "rimraf": "^5.0.5",
     "svelte": "^4.2.8",
-    "tailwindcss": "^3.3.6"
+    "tailwindcss": "^3.4.0"
   },
   "peerDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "*",


### PR DESCRIPTION
Happy release day! ✨ 

You can use this plugin with v3.4 without this update! This is just for those of you who use the CDN or a standalone binary and don't install Tailwind itself into your project but only have a config file. :)