### PR TITLE
Update README.md with note for naming the config file with .cjs extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ npm install -D prettier prettier-plugin-tailwindcss
 ```
 
 Then add the plugin to your Prettier config:
-
+>[!NOTE]
+>You need to name prettier config file as  `prettier.config.cjs`, if you have `"type":"module"` in your package.json
 ```js
 // prettier.config.js
 module.exports = {


### PR DESCRIPTION
…ttier.config.js doesn't work with type module projects

Most of the front end framework projects use "type":"module" when setting up so when using module.exports the prettier confine mentioned here (https://prettier.io/docs/en/configuration.html) specifies a .cjs extension