### PR TITLE
Fix detection of v4 projects on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Fix detection of v4 projects on Windows ([#265](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/265))
 
 ## [0.5.13] - 2024-03-27
 

--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,7 @@
 import * as fs from 'fs/promises'
 import { createRequire } from 'module'
 import * as path from 'path'
+import { pathToFileURL } from 'url'
 import clearModule from 'clear-module'
 import escalade from 'escalade/sync'
 import postcss from 'postcss'
@@ -181,8 +182,7 @@ async function loadV4(baseDir, pkgDir, entryPoint) {
   let pkgPath = localRequire.resolve('tailwindcss', {
     paths: [baseDir],
   })
-
-  let tw = await import(pkgPath)
+  let tw = await import(pathToFileURL(pkgPath).toString())
 
   // This is not Tailwind v4
   if (!tw.__unstable__loadDesignSystem) {


### PR DESCRIPTION
This fixes an issue where running Prettier against a Tailwind v4 project didn't load the v4 config on Windows but instead loaded the built-in v3 fallback version.

Fixes #264