### PR TITLE
Remove duplicate classes and excess whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Changed
+
+- Remove duplicate classes ([#272](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/272))
+- Remove extra whitespace around classes ([#272](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/272))
 
 ## [0.5.14] - 2024-04-15
 

--- a/src/options.js
+++ b/src/options.js
@@ -30,6 +30,12 @@ export const options = {
     description:
       'List of functions and tagged templates that contain sortable Tailwind classes',
   },
+  tailwindCollapseWhitespace: {
+    since: '0.5.12',
+    type: 'boolean',
+    category: 'Tailwind CSS',
+    description: 'Collapse whitespace after sorting Tailwind classes',
+  },
 }
 
 /** @typedef {import('prettier').RequiredOptions} RequiredOptions */

--- a/src/options.js
+++ b/src/options.js
@@ -30,12 +30,12 @@ export const options = {
     description:
       'List of functions and tagged templates that contain sortable Tailwind classes',
   },
-  tailwindCollapseWhitespace: {
-    since: '0.5.12',
+  tailwindPreserveWhitespace: {
+    since: '0.6.0',
     type: 'boolean',
-    default: [{ value: true }],
+    default: [{ value: false }],
     category: 'Tailwind CSS',
-    description: 'Collapse whitespace after sorting Tailwind classes',
+    description: 'Preserve whitespace around Tailwind classes when sorting',
   },
 }
 

--- a/src/options.js
+++ b/src/options.js
@@ -33,6 +33,7 @@ export const options = {
   tailwindCollapseWhitespace: {
     since: '0.5.12',
     type: 'boolean',
+    default: [{ value: true }],
     category: 'Tailwind CSS',
     description: 'Collapse whitespace after sorting Tailwind classes',
   },

--- a/src/sorting.js
+++ b/src/sorting.js
@@ -80,6 +80,17 @@ export function sortClasses(
     suffix = `${whitespace.pop() ?? ''}${classes.pop() ?? ''}`
   }
 
+  // Remove duplicates
+  classes = classes.filter((cls, index, arr) => {
+    if (arr.indexOf(cls) === index) {
+      return true
+    }
+
+    whitespace.splice(index - 1, 1)
+
+    return false
+  })
+
   classes = sortClassList(classes, { env })
 
   for (let i = 0; i < classes.length; i++) {

--- a/src/sorting.js
+++ b/src/sorting.js
@@ -56,7 +56,7 @@ export function sortClasses(
   }
 
   // Ignore class attributes containing `{{`, to match Prettier behaviour:
-  // https://github.com/prettier/prettier/blob/main/src/language-html/embed.js#L83-L88
+  // https://github.com/prettier/prettier/blob/8a88cdce6d4605f206305ebb9204a0cabf96a070/src/language-html/embed/class-names.js#L9
   if (classStr.includes('{{')) {
     return classStr
   }
@@ -97,8 +97,6 @@ export function sortClassList(classList, { env }) {
   return classNamesWithOrder
     .sort(([, a], [, z]) => {
       if (a === z) return 0
-      // if (a === null) return options.unknownClassPosition === 'start' ? -1 : 1
-      // if (z === null) return options.unknownClassPosition === 'start' ? 1 : -1
       if (a === null) return -1
       if (z === null) return 1
       return bigSign(a - z)

--- a/src/sorting.js
+++ b/src/sorting.js
@@ -73,6 +73,12 @@ export function sortClasses(
     collapseWhitespace = false
   }
 
+  // This class list is purely whitespace
+  // Collapse it to a single space if the option is enabled
+  if (/^[\t\r\f\n ]+$/.test(classStr) && collapseWhitespace) {
+    return ' '
+  }
+
   let result = ''
   let parts = classStr.split(/([\t\r\f\n ]+)/)
   let classes = parts.filter((_, i) => i % 2 === 0)

--- a/src/sorting.js
+++ b/src/sorting.js
@@ -45,11 +45,19 @@ function getClassOrderPolyfill(classes, { env }) {
  * @param {any} opts.env
  * @param {boolean} [opts.ignoreFirst]
  * @param {boolean} [opts.ignoreLast]
+ * @param {object} [opts.collapseWhitespace]
+ * @param {boolean} [opts.collapseWhitespace.start]
+ * @param {boolean} [opts.collapseWhitespace.end]
  * @returns {string}
  */
 export function sortClasses(
   classStr,
-  { env, ignoreFirst = false, ignoreLast = false },
+  {
+    env,
+    ignoreFirst = false,
+    ignoreLast = false,
+    collapseWhitespace = { start: true, end: true },
+  },
 ) {
   if (typeof classStr !== 'string' || classStr === '') {
     return classStr
@@ -61,6 +69,10 @@ export function sortClasses(
     return classStr
   }
 
+  if (!env.options.tailwindCollapseWhitespace) {
+    collapseWhitespace = false
+  }
+
   let result = ''
   let parts = classStr.split(/([\t\r\f\n ]+)/)
   let classes = parts.filter((_, i) => i % 2 === 0)
@@ -68,6 +80,10 @@ export function sortClasses(
 
   if (classes[classes.length - 1] === '') {
     classes.pop()
+  }
+
+  if (collapseWhitespace) {
+    whitespace = whitespace.map(() => ' ')
   }
 
   let prefix = ''
@@ -95,6 +111,15 @@ export function sortClasses(
 
   for (let i = 0; i < classes.length; i++) {
     result += `${classes[i]}${whitespace[i] ?? ''}`
+  }
+
+  if (collapseWhitespace) {
+    prefix = prefix.replace(/\s+$/g, ' ')
+    suffix = suffix.replace(/^\s+/g, ' ')
+
+    result = result
+      .replace(/^\s+/, collapseWhitespace.start ? '' : ' ')
+      .replace(/\s+$/, collapseWhitespace.end ? '' : ' ')
   }
 
   return prefix + result + suffix

--- a/src/sorting.js
+++ b/src/sorting.js
@@ -69,7 +69,7 @@ export function sortClasses(
     return classStr
   }
 
-  if (!env.options.tailwindCollapseWhitespace) {
+  if (env.options.tailwindPreserveWhitespace) {
     collapseWhitespace = false
   }
 

--- a/src/sorting.js
+++ b/src/sorting.js
@@ -39,6 +39,14 @@ function getClassOrderPolyfill(classes, { env }) {
   return classNamesWithOrder
 }
 
+/**
+ * @param {string} classStr
+ * @param {object} opts
+ * @param {any} opts.env
+ * @param {boolean} [opts.ignoreFirst]
+ * @param {boolean} [opts.ignoreLast]
+ * @returns {string}
+ */
 export function sortClasses(
   classStr,
   { env, ignoreFirst = false, ignoreLast = false },

--- a/tests/format.test.js
+++ b/tests/format.test.js
@@ -83,6 +83,22 @@ let javascript = [
     ';<div class={`flex flex${someVar}block block`} />',
     { tailwindCollapseWhitespace: true },
   ],
+  [
+    // This happens because we we look at class lists individually but
+    // a future improvement could be to dectect this case and not
+    // remove the space after flex.
+    ';<div class={`flex ` + `text-red-500`} />',
+    ';<div class={`flex` + `text-red-500`} />',
+    { tailwindCollapseWhitespace: true },
+  ],
+  [
+    // This happens because we we look at class lists individually but
+    // a future improvement could be to dectect this case and not
+    // remove the space after flex.
+    ';<div class={`flex` + `  ` + `text-red-500`} />',
+    ';<div class={`flex` + ` ` + `text-red-500`} />',
+    { tailwindCollapseWhitespace: true },
+  ],
 ]
 javascript = javascript.concat(
   javascript.map((test) => [

--- a/tests/format.test.js
+++ b/tests/format.test.js
@@ -19,7 +19,7 @@ let css = [
   [
     '@apply sm:p-0\n   p-0;',
     '@apply p-0\n   sm:p-0;',
-    { tailwindCollapseWhitespace: false },
+    { tailwindPreserveWhitespace: true },
   ],
 ]
 
@@ -60,32 +60,17 @@ let javascript = [
   [
     ';<div class="   m-0  sm:p-0  p-0   " />',
     ';<div class="m-0 p-0 sm:p-0" />',
-    { tailwindCollapseWhitespace: true },
   ],
   [
     ";<div class={'   m-0  sm:p-0  p-0   '} />",
     ";<div class={'m-0 p-0 sm:p-0'} />",
-    { tailwindCollapseWhitespace: true },
   ],
-  [
-    ';<div class={` sm:p-0\n  p-0   `} />',
-    ';<div class={`p-0 sm:p-0`} />',
-    { tailwindCollapseWhitespace: true },
-  ],
-  [
-    ';<div class="flex flex" />',
-    ';<div class="flex" />',
-    { tailwindCollapseWhitespace: true },
-  ],
-  [
-    ';<div class={`   flex  flex `} />',
-    ';<div class={`flex`} />',
-    { tailwindCollapseWhitespace: true },
-  ],
+  [';<div class={` sm:p-0\n  p-0   `} />', ';<div class={`p-0 sm:p-0`} />'],
+  [';<div class="flex flex" />', ';<div class="flex" />'],
+  [';<div class={`   flex  flex `} />', ';<div class={`flex`} />'],
   [
     ';<div class={`   flex  flex flex${someVar}block block`} />',
     ';<div class={`flex flex${someVar}block block`} />',
-    { tailwindCollapseWhitespace: true },
   ],
   [
     // This happens because we we look at class lists individually but
@@ -93,7 +78,6 @@ let javascript = [
     // remove the space after flex.
     ';<div class={`flex ` + `text-red-500`} />',
     ';<div class={`flex` + `text-red-500`} />',
-    { tailwindCollapseWhitespace: true },
   ],
   [
     // This happens because we we look at class lists individually but
@@ -101,7 +85,6 @@ let javascript = [
     // remove the space after flex.
     ';<div class={`flex` + `  ` + `text-red-500`} />',
     ';<div class={`flex` + ` ` + `text-red-500`} />',
-    { tailwindCollapseWhitespace: true },
   ],
 ]
 javascript = javascript.concat(
@@ -141,16 +124,8 @@ let vue = [
     `<div :class="\`p-0 sm:p-0 \${someVar}sm:block flex md:inline\`"></div>`,
   ],
 
-  [
-    `<div :class="'   flex  flex '"></div>`,
-    `<div :class="'flex'"></div>`,
-    { tailwindCollapseWhitespace: true },
-  ],
-  [
-    `<div :class="\`   flex  flex \`"></div>`,
-    `<div :class="\`flex\`"></div>`,
-    { tailwindCollapseWhitespace: true },
-  ],
+  [`<div :class="'   flex  flex '"></div>`, `<div :class="'flex'"></div>`],
+  [`<div :class="\`   flex  flex \`"></div>`, `<div :class="\`flex\`"></div>`],
 ]
 
 let glimmer = [
@@ -187,16 +162,11 @@ let glimmer = [
     `<div class='{{if @isTrue (nope "border- border-l-4" @borderColor)}}'></div>`,
   ],
 
-  [
-    `<div class='flex  flex '></div>`,
-    `<div class='flex'></div>`,
-    { tailwindCollapseWhitespace: true },
-  ],
+  [`<div class='flex  flex '></div>`, `<div class='flex'></div>`],
 
   [
     `<div class='sm:p-0   p-0  p-0 {{someVar}}sm:block flex md:inline   flex '></div>`,
     `<div class='p-0 sm:p-0 {{someVar}}sm:block flex md:inline'></div>`,
-    { tailwindCollapseWhitespace: true },
   ],
 ]
 
@@ -295,7 +265,7 @@ describe('whitespace', () => {
       `;<div className={' underline text-red-500  flex '}></div>`,
       {
         parser: 'babel',
-        tailwindCollapseWhitespace: false,
+        tailwindPreserveWhitespace: true,
       },
     )
     expect(result).toEqual(
@@ -306,9 +276,6 @@ describe('whitespace', () => {
   test('whitespace can be collapsed around classes', async () => {
     let result = await format(
       '<div class=" underline text-red-500  flex "></div>',
-      {
-        tailwindCollapseWhitespace: true,
-      },
     )
     expect(result).toEqual('<div class="flex text-red-500 underline"></div>')
   })
@@ -318,7 +285,6 @@ describe('whitespace', () => {
       ';<div className={`underline text-red-500 ${foo}-bar flex`}></div>',
       {
         parser: 'babel',
-        tailwindCollapseWhitespace: true,
       },
     )
     expect(result).toEqual(

--- a/tests/format.test.js
+++ b/tests/format.test.js
@@ -16,7 +16,11 @@ let css = [
   t`@apply ${yes};`,
   t`/* @apply ${no}; */`,
   t`@not-apply ${no};`,
-  ['@apply sm:p-0\n   p-0;', '@apply p-0\n   sm:p-0;'],
+  [
+    '@apply sm:p-0\n   p-0;',
+    '@apply p-0\n   sm:p-0;',
+    { tailwindCollapseWhitespace: false },
+  ],
 ]
 
 let javascript = [
@@ -286,11 +290,12 @@ describe('whitespace', () => {
     expect(result).toEqual('<div class="{{ this is ignored }}"></div>')
   })
 
-  test('whitespace is preserved around classes', async () => {
+  test('whitespace can be preserved around classes', async () => {
     let result = await format(
       `;<div className={' underline text-red-500  flex '}></div>`,
       {
         parser: 'babel',
+        tailwindCollapseWhitespace: false,
       },
     )
     expect(result).toEqual(

--- a/tests/plugins.test.js
+++ b/tests/plugins.test.js
@@ -366,7 +366,7 @@ import Custom from '../components/Custom.astro'
           `<div class="sm:p-0 p-0 {someVar}sm:block md:inline flex" />`,
           `<div class="p-0 sm:p-0 {someVar}sm:block flex md:inline" />`,
         ],
-        ['<div class={`sm:p-0\np-0`} />', '<div\n  class={`p-0\nsm:p-0`}\n/>'],
+        ['<div class={`sm:p-0\np-0`} />', '<div class={`p-0 sm:p-0`} />'],
         t`{#await promise()} <div class="${yes}" /> {:then} <div class="${yes}" /> {/await}`,
         t`{#await promise() then} <div class="${yes}" /> {/await}`,
       ],

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -23,7 +23,7 @@ module.exports.t = function t(strings, ...values) {
     output += string + value
   })
 
-  return [input, output]
+  return [input, output, { tailwindCollapseWhitespace: true }]
 }
 
 let pluginPath = path.resolve(__dirname, '../dist/index.mjs')

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -23,7 +23,7 @@ module.exports.t = function t(strings, ...values) {
     output += string + value
   })
 
-  return [input, output, { tailwindCollapseWhitespace: true }]
+  return [input, output, { tailwindPreserveWhitespace: true }]
 }
 
 let pluginPath = path.resolve(__dirname, '../dist/index.mjs')


### PR DESCRIPTION
This PR introduces two new features to the plugin: removal of duplicate class names and removal of excess / unncecessary whitespace.

## Removal of duplicate classes

This feature is *always* enabled. An example of this feature in action is shown below — notice that the extra `p-4` class is removed:

```diff
- <div className="sm:p-0 p-4 p-4" />
+ <div className="p-4 sm:p-0" />
```

## Removal of excess / unnecessary whitespace

This was originally implemented in #70 but reverted due to issues breaking code that relies on the presence of whitespace in a class list. This PR enables this feature by default _but allows you to disable it (via `tailwindPreserveWhitespace`)_ should you run into issues. For example, the following code will be formatted as shown below:

```diff
- <div className=" sm:p-0 \n      p-4  " />
+ <div className="p-4 sm:p-0" />
```

### What can break?

As mentioned above, removal of whitespace in a class list can break code that relies on the presence of leading or trailing whitespace. e.g. when concatenating strings of classes. In the following code, you can see the _after_ version results in a non-existent class. This is a known limitation and is why this feature can be disabled.

```diff
- <div className={`flex ` + `text-red-500`} />
+ <div className={`flex` + `text-red-500`} />
```

To disable this feature and preserve whitespace in class lists, set the option `tailwindPreserveWhitespace` to `true` in your Prettier configuration:

```json5
{
  // … your config
  "tailwindPreserveWhitespace": true
}
```

If you don't want to disable the feature for your entire project you can use one of the following methods:

1. Use `// prettier-ignore` to prevent Prettier from formatting the line:
```diff
// prettier-ignore
<div className={`flex ` + `text-red-500`} />
```

2. Use a separate, whitespace-only string.

When sorting we will ensure that a class list that is composed of only whitespace is not removed. It will, however, be shortened to a single space:

```diff
- <div className={`flex  ` + `   ` + ` text-red-500`} />
+ <div className={`flex` + ` ` + `text-red-500`} />
```

3. Disable the feature for just one file. You can do this by utilizing the "overrides" feature in Prettier. For example, you can add the following to your `.prettierrc` file and it will only preserve whitespace in `src/components/MyComponent.jsx`:

```json5
{
  // … your config
  "overrides": [
    {
      "files": "src/components/MyComponent.jsx",
      "options": {
        "tailwindPreserveWhitespace": true
      }
    }
  ]
}
```
