### PR TITLE
Improve handling of whitespace and duplicate class removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add the `tailwindPreserveDuplicates` option to keep duplicate classes ([#276](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/276))
+- Add new `tailwindPreserveDuplicates` option to disable removal of duplicate classes ([#276](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/276))
 
 ### Fixed
 
 - Improve handling of whitespace removal when concatenating strings ([#276](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/276))
-- Fix a bug where angular expressions may produce invalid code after sorting ([#276](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/276))
+- Fix a bug where Angular expressions may produce invalid code after sorting ([#276](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/276))
 - Disabled whitespace and duplicate class removal for Liquid and Svelte ([#276](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/276))
 
 ## [0.6.0] - 2024-05-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Added
+
+- Add the `tailwindPreserveDuplicates` option to keep duplicate classes ([#276](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/276))
+
+### Fixed
+
+- Improve handling of whitespace removal when concatenating strings ([#276](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/276))
+- Fix a bug where angular expressions may produce invalid code after sorting ([#276](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/276))
+- Disabled whitespace and duplicate class removal for Liquid and Svelte ([#276](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/276))
 
 ## [0.6.0] - 2024-05-30
 

--- a/README.md
+++ b/README.md
@@ -141,9 +141,9 @@ Once added, tag your strings with the function and the plugin will sort them:
 const mySortedClasses = tw`bg-white p-4 dark:bg-black`
 ```
 
-## Preserving Whitespace
+## Preserving whitespace
 
-This plugin removes whitespace between classes to ensure consistent formatting. If you prefer to preserve whitespace between classes, you can use the `tailwindPreserveWhitespace` option:
+This plugin automatically removes unnecessary whitespace between classes to ensure consistent formatting. If you prefer to preserve whitespace, you can use the `tailwindPreserveWhitespace` option:
 
 ```json5
 // .prettierrc
@@ -166,11 +166,11 @@ function MyButton({ isHovering, children }) {
 }
 ```
 
-## Preserving Duplicate Classes
+## Preserving duplicate classes
 
-This plugin removes duplicate classes which can be useful for long class lists. However, in some templating languages like FLuid, what we perceive as duplicate classes might actually be a combination of classes, variables, and templating language syntax.
+This plugin automatically removes duplicate classes from your class lists. However, this can cause issues in some templating languages, like Fluid or Blade, where we can't distinguish between classes and the templating syntax.
 
-If removing duplicate classes is causing issues in your project, you can use the `tailwindPreserveDuplicates` option to ensure they're kept:
+If removing duplicate classes is causing issues in your project, you can use the `tailwindPreserveDuplicates` option to disable this behavior:
 
 ```json5
 // .prettierrc

--- a/README.md
+++ b/README.md
@@ -141,6 +141,57 @@ Once added, tag your strings with the function and the plugin will sort them:
 const mySortedClasses = tw`bg-white p-4 dark:bg-black`
 ```
 
+## Preserving Whitespace
+
+This plugin removes whitespace between classes to ensure consistent formatting. If you prefer to preserve whitespace between classes, you can use the `tailwindPreserveWhitespace` option:
+
+```json5
+// .prettierrc
+{
+  "tailwindPreserveWhitespace": true,
+}
+```
+
+With this configuration, any whitespace surrounding classes will be preserved:
+
+```jsx
+import clsx from 'clsx'
+
+function MyButton({ isHovering, children }) {
+  return (
+    <button className=" rounded  bg-blue-500 px-4  py-2     text-base text-white ">
+      {children}
+    </button>
+  )
+}
+```
+
+## Preserving Duplicate Classes
+
+This plugin removes duplicate classes which can be useful for long class lists. However, in some templating languages like FLuid, what we perceive as duplicate classes might actually be a combination of classes, variables, and templating language syntax.
+
+If removing duplicate classes is causing issues in your project, you can use the `tailwindPreserveDuplicates` option to ensure they're kept:
+
+```json5
+// .prettierrc
+{
+  "tailwindPreserveDuplicates": true,
+}
+```
+
+With this configuration, anything we perceive as duplicate classes will be preserved:
+
+```html
+<div
+  class="
+    {f:if(condition: isCompact, then: 'grid-cols-3', else: 'grid-cols-5')}
+    {f:if(condition: isDark, then: 'bg-black/50', else: 'bg-white/50')}
+    grid gap-4 p-4
+  "
+>
+</div>
+```
+
 ## Compatibility with other Prettier plugins
 
 This plugin uses Prettier APIs that can only be used by one plugin at a time, making it incompatible with other Prettier plugins implemented the same way. To solve this we've added explicit per-plugin workarounds that enable compatibility with the following Prettier plugins:

--- a/src/index.js
+++ b/src/index.js
@@ -908,10 +908,7 @@ function transformSvelte(ast, { env, changes }) {
           env,
           ignoreFirst: i > 0 && !/^\s/.test(value.raw),
           ignoreLast: i < attr.value.length - 1 && !/\s$/.test(value.raw),
-          collapseWhitespace: {
-            start: i === 0,
-            end: i >= attr.value.length - 1,
-          },
+          collapseWhitespace: false,
         })
         value.data = same
           ? value.raw
@@ -919,24 +916,16 @@ function transformSvelte(ast, { env, changes }) {
               env,
               ignoreFirst: i > 0 && !/^\s/.test(value.data),
               ignoreLast: i < attr.value.length - 1 && !/\s$/.test(value.data),
-              collapseWhitespace: {
-                start: i === 0,
-                end: i >= attr.value.length - 1,
-              },
+              collapseWhitespace: false,
             })
       } else if (value.type === 'MustacheTag') {
         visit(value.expression, {
           Literal(node, parent, key) {
-            let isConcat =
-              parent?.type === 'BinaryExpression' && parent?.operator === '+'
-
             if (isStringLiteral(node)) {
+              let before = node.raw
               let sorted = sortStringLiteral(node, {
                 env,
-                collapseWhitespace: {
-                  start: !(isConcat && key === 'right'),
-                  end: !(isConcat && key === 'left'),
-                },
+                collapseWhitespace: false,
               })
 
               if (sorted) {
@@ -950,15 +939,10 @@ function transformSvelte(ast, { env, changes }) {
             }
           },
           TemplateLiteral(node, parent, key) {
-            let isConcat =
-              parent?.type === 'BinaryExpression' && parent?.operator === '+'
-
+            let before = node.quasis.map((quasi) => quasi.value.raw)
             let sorted = sortTemplateLiteral(node, {
               env,
-              collapseWhitespace: {
-                start: !(isConcat && key === 'right'),
-                end: !(isConcat && key === 'left'),
-              },
+              collapseWhitespace: false,
             })
 
             if (sorted) {

--- a/src/index.js
+++ b/src/index.js
@@ -808,7 +808,9 @@ function transformMelody(ast, { env, changes }) {
         return
       }
 
-      const isConcat = parent.type === 'BinaryConcatExpression'
+      const isConcat =
+        parent.type === 'BinaryConcatExpression' ||
+        parent.type === 'BinaryAddExpression'
 
       node.value = sortClasses(node.value, {
         env,

--- a/src/index.js
+++ b/src/index.js
@@ -364,10 +364,7 @@ function transformLiquid(ast, { env }) {
           env,
           ignoreFirst: i > 0 && !/^\s/.test(node.value),
           ignoreLast: i < attr.value.length - 1 && !/\s$/.test(node.value),
-          collapseWhitespace: {
-            start: i === 0,
-            end: i >= attr.value.length - 1,
-          },
+          collapseWhitespace: false,
         })
 
         changes.push({

--- a/src/index.js
+++ b/src/index.js
@@ -364,6 +364,7 @@ function transformLiquid(ast, { env }) {
           env,
           ignoreFirst: i > 0 && !/^\s/.test(node.value),
           ignoreLast: i < attr.value.length - 1 && !/\s$/.test(node.value),
+          removeDuplicates: false,
           collapseWhitespace: false,
         })
 
@@ -905,6 +906,7 @@ function transformSvelte(ast, { env, changes }) {
           env,
           ignoreFirst: i > 0 && !/^\s/.test(value.raw),
           ignoreLast: i < attr.value.length - 1 && !/\s$/.test(value.raw),
+          removeDuplicates: false,
           collapseWhitespace: false,
         })
         value.data = same
@@ -913,6 +915,7 @@ function transformSvelte(ast, { env, changes }) {
               env,
               ignoreFirst: i > 0 && !/^\s/.test(value.data),
               ignoreLast: i < attr.value.length - 1 && !/\s$/.test(value.data),
+              removeDuplicates: false,
               collapseWhitespace: false,
             })
       } else if (value.type === 'MustacheTag') {
@@ -922,6 +925,7 @@ function transformSvelte(ast, { env, changes }) {
               let before = node.raw
               let sorted = sortStringLiteral(node, {
                 env,
+                removeDuplicates: false,
                 collapseWhitespace: false,
               })
 
@@ -939,6 +943,7 @@ function transformSvelte(ast, { env, changes }) {
             let before = node.quasis.map((quasi) => quasi.value.raw)
             let sorted = sortTemplateLiteral(node, {
               env,
+              removeDuplicates: false,
               collapseWhitespace: false,
             })
 

--- a/src/options.js
+++ b/src/options.js
@@ -37,6 +37,13 @@ export const options = {
     category: 'Tailwind CSS',
     description: 'Preserve whitespace around Tailwind classes when sorting',
   },
+  tailwindPreserveDuplicates: {
+    since: '0.6.1',
+    type: 'boolean',
+    default: [{ value: false }],
+    category: 'Tailwind CSS',
+    description: 'Preserve duplicate classes inside a class list when sorting',
+  },
 }
 
 /** @typedef {import('prettier').RequiredOptions} RequiredOptions */

--- a/src/sorting.js
+++ b/src/sorting.js
@@ -103,15 +103,17 @@ export function sortClasses(
   }
 
   // Remove duplicates
-  classes = classes.filter((cls, index, arr) => {
-    if (arr.indexOf(cls) === index) {
-      return true
-    }
+  if (!env.options.tailwindPreserveDuplicates) {
+    classes = classes.filter((cls, index, arr) => {
+      if (arr.indexOf(cls) === index) {
+        return true
+      }
 
-    whitespace.splice(index - 1, 1)
+      whitespace.splice(index - 1, 1)
 
-    return false
-  })
+      return false
+    })
+  }
 
   classes = sortClassList(classes, { env })
 

--- a/src/sorting.js
+++ b/src/sorting.js
@@ -45,6 +45,7 @@ function getClassOrderPolyfill(classes, { env }) {
  * @param {any} opts.env
  * @param {boolean} [opts.ignoreFirst]
  * @param {boolean} [opts.ignoreLast]
+ * @param {boolean} [opts.removeDuplicates]
  * @param {object} [opts.collapseWhitespace]
  * @param {boolean} [opts.collapseWhitespace.start]
  * @param {boolean} [opts.collapseWhitespace.end]
@@ -56,6 +57,7 @@ export function sortClasses(
     env,
     ignoreFirst = false,
     ignoreLast = false,
+    removeDuplicates = true,
     collapseWhitespace = { start: true, end: true },
   },
 ) {
@@ -71,6 +73,10 @@ export function sortClasses(
 
   if (env.options.tailwindPreserveWhitespace) {
     collapseWhitespace = false
+  }
+
+  if (env.options.tailwindPreserveDuplicates) {
+    removeDuplicates = false
   }
 
   // This class list is purely whitespace
@@ -102,8 +108,7 @@ export function sortClasses(
     suffix = `${whitespace.pop() ?? ''}${classes.pop() ?? ''}`
   }
 
-  // Remove duplicates
-  if (!env.options.tailwindPreserveDuplicates) {
+  if (removeDuplicates) {
     classes = classes.filter((cls, index, arr) => {
       if (arr.indexOf(cls) === index) {
         return true

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -15,7 +15,7 @@ export interface Customizations {
 
 export interface TransformerContext {
   env: TransformerEnv
-  changes: { text: string; loc: any }[]
+  changes: StringChange[]
 }
 
 export interface TransformerEnv {
@@ -38,4 +38,11 @@ export interface InternalOptions {
 declare module 'prettier' {
   interface RequiredOptions extends InternalOptions {}
   interface ParserOptions extends InternalOptions {}
+}
+
+export interface StringChange {
+  start: number
+  end: number
+  before: string
+  after: string
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+/** @typedef {import('./types.js').StringChange} StringChange */
+
 // For loading prettier plugins only if they exist
 export function loadIfExists(name) {
   try {
@@ -37,4 +39,26 @@ export function visit(ast, callbackMap) {
     }
   }
   _visit(ast)
+}
+
+/**
+ * Apply the changes to the string such that a change in the length
+ * of the string does not break the indexes of the subsequent changes.
+ * @param {string} str
+ * @param {StringChange[]} changes
+ */
+export function spliceChangesIntoString(str, changes) {
+  // Sort all changes in reverse order so we apply them from the end of the string
+  // to the beginning. This way, the indexes for the changes after the current one
+  // will still be correct after applying the current one.
+  changes.sort((a, b) => {
+    return b.end - a.end || b.start - a.start
+  })
+
+  // Splice in each change to the string
+  for (let change of changes) {
+    str = str.slice(0, change.start) + change.after + str.slice(change.end)
+  }
+
+  return str
 }

--- a/tests/format.test.js
+++ b/tests/format.test.js
@@ -10,6 +10,14 @@ let html = [
   t`<div class=""></div>`,
   // Ensure duplicate classes are removed
   ['<div class="sm:p-0 p-0 p-0"></div>', '<div class="p-0 sm:p-0"></div>'],
+  // Ensure duplicate can be kept
+  [
+    '<div class="sm:p-0 p-0 p-0"></div>',
+    '<div class="p-0 p-0 sm:p-0"></div>',
+    {
+      tailwindPreserveDuplicates: true,
+    },
+  ],
 ]
 
 let css = [

--- a/tests/format.test.js
+++ b/tests/format.test.js
@@ -193,6 +193,11 @@ let tests = {
     t`<div [ngClass]="{ '${yes}': (some.thing | urlPipe: { option: true } | async), '${yes}': true }"></div>`,
     t`<div [ngClass]="{ '${yes}': foo && bar?.['baz'] }" class="${yes}"></div>`,
 
+    [
+      `<div [ngClass]="' flex ' + ' underline ' + ' block '"></div>`,
+      `<div [ngClass]="'flex ' + ' underline' + ' block'"></div>`,
+    ],
+
     // TODO: Enable this test — it causes console noise but not a failure
     // t`<div [ngClass]="{ '${no}': foo && definitely&a:syntax*error }" class="${yes}"></div>`,
   ],

--- a/tests/format.test.js
+++ b/tests/format.test.js
@@ -73,18 +73,12 @@ let javascript = [
     ';<div class={`flex flex${someVar}block block`} />',
   ],
   [
-    // This happens because we we look at class lists individually but
-    // a future improvement could be to dectect this case and not
-    // remove the space after flex.
     ';<div class={`flex ` + `text-red-500`} />',
-    ';<div class={`flex` + `text-red-500`} />',
+    ';<div class={`flex ` + `text-red-500`} />',
   ],
   [
-    // This happens because we we look at class lists individually but
-    // a future improvement could be to dectect this case and not
-    // remove the space after flex.
-    ';<div class={`flex` + `  ` + `text-red-500`} />',
-    ';<div class={`flex` + ` ` + `text-red-500`} />',
+    ';<div class={`flex ` + `  ` + `text-red-500`} />',
+    ';<div class={`flex ` + ` ` + `text-red-500`} />',
   ],
 ]
 javascript = javascript.concat(
@@ -126,6 +120,14 @@ let vue = [
 
   [`<div :class="'   flex  flex '"></div>`, `<div :class="'flex'"></div>`],
   [`<div :class="\`   flex  flex \`"></div>`, `<div :class="\`flex\`"></div>`],
+  [
+    `<div :class="' flex ' + ' underline '"></div>`,
+    `<div :class="'flex ' + ' underline'"></div>`,
+  ],
+  [
+    `<div :class="' sm:p-5 ' + ' flex ' + ' underline ' + ' sm:m-5 '"></div>`,
+    `<div :class="'sm:p-5 ' + ' flex' + ' underline' + ' sm:m-5'"></div>`,
+  ],
 ]
 
 let glimmer = [

--- a/tests/plugins.test.js
+++ b/tests/plugins.test.js
@@ -140,6 +140,15 @@ let tests = [
         t`<section class="${yes} {{ i }}text-center"></section>`,
         t`<section class="text-center{{ i }} ${yes}"></section>`,
         t`<section class="{{ i }}text-center ${yes}"></section>`,
+
+        [
+          `<div class=" sm:flex   underline  block"></div>`,
+          `<div class="block underline sm:flex"></div>`,
+        ],
+        [
+          `<div class="{{ ' flex ' + ' underline ' + ' block ' }}"></div>`,
+          `<div class="{{ 'flex ' + ' underline' + ' block' }}"></div>`,
+        ],
       ],
     },
   },
@@ -154,6 +163,11 @@ let tests = [
         ],
         [
           `a.p-4.bg-blue-600(class='sm:p-0 md:p-4', href='//example.com') Example`,
+          `a.bg-blue-600.p-4(class='sm:p-0 md:p-4', href='//example.com') Example`,
+        ],
+
+        [
+          `a.p-4.bg-blue-600(class=' sm:p-0     md:p-4 ', href='//example.com') Example`,
           `a.bg-blue-600.p-4(class='sm:p-0 md:p-4', href='//example.com') Example`,
         ],
 
@@ -257,6 +271,18 @@ let tests = [
         t`<div class='${yes} {% include 'foo', bar: true %}'></div>`,
         t`<div class='${yes} foo--{{ id }}'></div>`,
         t`<div class='${yes} {{ id }}'></div>`,
+
+        // Whitespace removal is disabled for Liquid
+        // due to the way Liquid prints the AST
+        // (the length of the output MUST NOT change)
+        [
+          `<div class=' sm:flex   underline  block'></div>`,
+          `<div class=' block   underline  sm:flex'></div>`,
+        ],
+        [
+          `<div class='{{ ' flex ' + ' underline ' + ' block ' }}'></div>`,
+          `<div class='{{ ' flex ' + ' underline ' + ' block ' }}'></div>`,
+        ],
       ],
     },
   },
@@ -289,6 +315,18 @@ let tests = [
   '${yes}',
 ]/>`,
         t`<div class=['${yes}', 'underline', someVariable]/>`,
+
+        [
+          `<div class=' sm:flex   underline  block'/>`,
+          `<div class='block underline sm:flex'/>`,
+        ],
+
+        // TODO: An improvement to the plugin would be to remove the whitespace
+        // in this scenario:
+        [
+          `<div class=[' flex ' + ' underline ' + ' block ']/>`,
+          `<div class=[' flex ' + ' underline ' + ' block ']/>`,
+        ],
       ],
     },
   },
@@ -332,6 +370,15 @@ import Custom from '../components/Custom.astro'
 </div>`,
         t`<MyReactComponent className="${yes}" />`,
         t`<MyReactComponent className={'${yes}'} />`,
+
+        [
+          `<div class=" sm:flex   underline  block"></div>`,
+          `<div class="block underline sm:flex"></div>`,
+        ],
+        [
+          `<div class:list={[' flex ' + ' underline ' + ' block ']}></div>`,
+          `<div class:list={['flex ' + ' underline' + ' block']}></div>`,
+        ],
       ],
     },
   },
@@ -369,6 +416,20 @@ import Custom from '../components/Custom.astro'
         ['<div class={`sm:p-0\np-0`} />', '<div class={`p-0 sm:p-0`} />'],
         t`{#await promise()} <div class="${yes}" /> {:then} <div class="${yes}" /> {/await}`,
         t`{#await promise() then} <div class="${yes}" /> {/await}`,
+
+        // Whitespace removal is applied by Svelte itself
+        [
+          `<div class=" sm:flex   underline  block"></div>`,
+          `<div class=" block underline sm:flex"></div>`,
+        ],
+
+        // Whitespace removal does not work in Svelte
+        // due to how Svelte's parser and printer work
+        // (the length of the text MUST NOT change)
+        [
+          `<div class={' flex ' + ' underline ' + ' block '}></div>`,
+          `<div class={' flex ' + ' underline ' + ' block '}></div>`,
+        ],
       ],
     },
   },


### PR DESCRIPTION
This PR does a handful of things:

## Tweak whitespace handling inside concatenation expressions

For example, in the following code:

```jsx
<div className={" flex " + borderClass + " underline sm:block "} />
```

After formatting the output is

```diff
- <div className={" flex " + borderClass + " underline sm:block "} />
+ <div className={"flex" + borderClass + "underline sm:block"} />
```

However, this results in invalid class names. We'll now only remove the whitespace on one side of each of the strings (depending on if it's the start or not), so the output will be:

```diff
- <div className={" flex " + borderClass + " underline sm:block "} />
+ <div className={"flex " + borderClass + " underline sm:block"} />
```

This means you're less likely to need to add extra whitespace only strings or disable whitespace removal to ensure the output stays functionally the same.

## Add `tailwindPreserveDuplicates` option

Normally removing duplicate classes (whether known or unknown) is a safe operation to do. However, when using a templating language like Fluid or Blade it's possible to have "duplicate" classes that are important because they're compiler directives. The problem is that Prettier only considers the file to be HTML so we don't know about these directives.

For example, in Fluid, you might have something like this:

```html
<div
  class="
    {f:if(condition: isCompact, then: 'grid-cols-3', else: 'grid-cols-5')}
    {f:if(condition: isDark, then: 'bg-black/50', else: 'bg-white/50')}
    grid gap-4 p-4
  "
>
</div>
```

Our plugin sees `{f:if(condition:` as a class, `isCompact,` as a class, `then:` as a class, etc… but doesn't know that they are directives so they are treated like unknown classes and moved to the front of the class list in their original order.

Further, when we remove duplicate classes the second `then:`, `else:`, and `{f:if(condition:`, etc… are all removed, resulting in invalid Fluid code:

```html
<div
  class="
    {f:if(condition: isCompact, then: 'grid-cols-3', else: 'grid-cols-5')}
    isDark,  'bg-black/50', 'bg-white/50')}
    grid gap-4 p-4
  "
>
</div>
```

To fix this, we've added a new `tailwindPreserveDuplicates` option that prevents this behavior. It is `false` by default but can be enabled if you're using a templating language where this is a problem:

```json5
{
  // … your config
  "tailwindPreserveDuplicates": true
}
```

## Fixes some bugs

- Angular expressions that had either duplicate classes or whitespace removed could result in mangled output. This is now fixed.
- Removal of duplicate classes and whitespace has been disabled for Svelte and Liquid files. This is due to limitations in their respective plugins that make it difficult to change the length of the resulting code (in some situations) and still output valid code.

Fixes #273