### PR TITLE
Only remove duplicate Tailwind classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Changed
+
+- Only remove duplicate Tailwind classes ([#277](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/277))
 
 ## [0.6.1] - 2024-05-31
 

--- a/src/index.js
+++ b/src/index.js
@@ -878,7 +878,10 @@ function transformPug(ast, { env }) {
     const classes = ast.tokens
       .slice(startIdx, endIdx + 1)
       .map((token) => token.val)
-    const classList = sortClassList(classes, { env })
+    const { classList } = sortClassList(classes, {
+      env,
+      removeDuplicates: false,
+    })
 
     for (let i = startIdx; i <= endIdx; i++) {
       ast.tokens[i].val = classList[i - startIdx]

--- a/src/index.js
+++ b/src/index.js
@@ -878,6 +878,7 @@ function transformPug(ast, { env }) {
     const classes = ast.tokens
       .slice(startIdx, endIdx + 1)
       .map((token) => token.val)
+
     const { classList } = sortClassList(classes, {
       env,
       removeDuplicates: false,

--- a/src/sorting.js
+++ b/src/sorting.js
@@ -109,14 +109,23 @@ export function sortClasses(
   }
 
   if (removeDuplicates) {
+    let indicesToRemove = []
     classes = classes.filter((cls, index, arr) => {
       if (arr.indexOf(cls) === index) {
         return true
       }
 
-      whitespace.splice(index - 1, 1)
-
+      indicesToRemove.push(index - 1)
       return false
+    })
+
+    let startIndex = 0
+    whitespace = whitespace.filter((_, index) => {
+      if (indicesToRemove[startIndex] === index) {
+        startIndex++
+        return false
+      }
+      return true
     })
   }
 

--- a/src/sorting.js
+++ b/src/sorting.js
@@ -109,9 +109,12 @@ export function sortClasses(
   }
 
   if (removeDuplicates) {
+    let seenClasses = new Set()
     let indicesToRemove = []
-    classes = classes.filter((cls, index, arr) => {
-      if (arr.indexOf(cls) === index) {
+
+    classes = classes.filter((cls, index) => {
+      if (!seenClasses.has(cls)) {
+        seenClasses.add(cls)
         return true
       }
 

--- a/src/sorting.js
+++ b/src/sorting.js
@@ -39,6 +39,19 @@ function getClassOrderPolyfill(classes, { env }) {
   return classNamesWithOrder
 }
 
+function reorderClasses(classList, { env }) {
+  let orderedClasses = env.context.getClassOrder
+    ? env.context.getClassOrder(classList)
+    : getClassOrderPolyfill(classList, { env })
+
+  return orderedClasses.sort(([, a], [, z]) => {
+    if (a === z) return 0
+    if (a === null) return -1
+    if (z === null) return 1
+    return bigSign(a - z)
+  })
+}
+
 /**
  * @param {string} classStr
  * @param {object} opts
@@ -129,20 +142,13 @@ export function sortClasses(
 }
 
 export function sortClassList(classList, { env, removeDuplicates }) {
+  // Re-order classes based on the Tailwind CSS configuration
+  let orderedClasses = reorderClasses(classList, { env })
+
+  // Remove duplicate Tailwind classes
   if (env.options.tailwindPreserveDuplicates) {
     removeDuplicates = false
   }
-
-  let orderedClasses = env.context.getClassOrder
-    ? env.context.getClassOrder(classList)
-    : getClassOrderPolyfill(classList, { env })
-
-  orderedClasses.sort(([, a], [, z]) => {
-    if (a === z) return 0
-    if (a === null) return -1
-    if (z === null) return 1
-    return bigSign(a - z)
-  })
 
   let removedIndices = new Set()
 

--- a/src/sorting.js
+++ b/src/sorting.js
@@ -121,6 +121,8 @@ export function sortClasses(
     suffix = `${whitespace.pop() ?? ''}${classes.pop() ?? ''}`
   }
 
+  classes = sortClassList(classes, { env })
+
   if (removeDuplicates) {
     let seenClasses = new Set()
     let indicesToRemove = new Set()
@@ -138,8 +140,6 @@ export function sortClasses(
 
     whitespace = whitespace.filter((_, index) => !indicesToRemove.has(index))
   }
-
-  classes = sortClassList(classes, { env })
 
   for (let i = 0; i < classes.length; i++) {
     result += `${classes[i]}${whitespace[i] ?? ''}`

--- a/src/sorting.js
+++ b/src/sorting.js
@@ -164,7 +164,7 @@ export function sortClasses(
 }
 
 export function sortClassList(classList, { env }) {
-  let classNamesWithOrder = reorderClasses(classList, { env })
+  let orderedClasses = reorderClasses(classList, { env })
 
-  return classNamesWithOrder.map(([className]) => className)
+  return orderedClasses.map(([className]) => className)
 }

--- a/src/sorting.js
+++ b/src/sorting.js
@@ -125,12 +125,11 @@ export function sortClasses(
 
   if (removeDuplicates) {
     let seenClasses = new Set()
-    let indicesToRemove = new Set()
+    let removedIndices = new Set()
 
     orderedClasses = orderedClasses.filter(([cls, order], index) => {
       if (seenClasses.has(cls)) {
-        // Remove the whitespace before the duplicate class
-        indicesToRemove.add(index - 1)
+        removedIndices.add(index)
         return false
       }
 
@@ -142,7 +141,8 @@ export function sortClasses(
       return true
     })
 
-    whitespace = whitespace.filter((_, index) => !indicesToRemove.has(index))
+    // Remove all whitespace where the class after it was removed
+    whitespace = whitespace.filter((_, index) => !removedIndices.has(index + 1))
   }
 
   classes = orderedClasses.map(([className]) => className)

--- a/src/sorting.js
+++ b/src/sorting.js
@@ -110,26 +110,20 @@ export function sortClasses(
 
   if (removeDuplicates) {
     let seenClasses = new Set()
-    let indicesToRemove = []
+    let indicesToRemove = new Set()
 
     classes = classes.filter((cls, index) => {
-      if (!seenClasses.has(cls)) {
-        seenClasses.add(cls)
-        return true
-      }
-
-      indicesToRemove.push(index - 1)
-      return false
-    })
-
-    let startIndex = 0
-    whitespace = whitespace.filter((_, index) => {
-      if (indicesToRemove[startIndex] === index) {
-        startIndex++
+      if (seenClasses.has(cls)) {
+        // Remove the whitespace before the duplicate class
+        indicesToRemove.add(index - 1)
         return false
       }
+
+      seenClasses.add(cls)
       return true
     })
+
+    whitespace = whitespace.filter((_, index) => !indicesToRemove.has(index))
   }
 
   classes = sortClassList(classes, { env })

--- a/src/sorting.js
+++ b/src/sorting.js
@@ -141,7 +141,7 @@ export function sortClasses(
       return true
     })
 
-    // Remove all whitespace where the class after it was removed
+    // Remove whitespace that appeared before a removed classes
     whitespace = whitespace.filter((_, index) => !removedIndices.has(index + 1))
   }
 

--- a/src/sorting.js
+++ b/src/sorting.js
@@ -39,6 +39,19 @@ function getClassOrderPolyfill(classes, { env }) {
   return classNamesWithOrder
 }
 
+function reorderClasses(classList, { env }) {
+  let classNamesWithOrder = env.context.getClassOrder
+    ? env.context.getClassOrder(classList)
+    : getClassOrderPolyfill(classList, { env })
+
+  return classNamesWithOrder.sort(([, a], [, z]) => {
+    if (a === z) return 0
+    if (a === null) return -1
+    if (z === null) return 1
+    return bigSign(a - z)
+  })
+}
+
 /**
  * @param {string} classStr
  * @param {object} opts
@@ -145,16 +158,7 @@ export function sortClasses(
 }
 
 export function sortClassList(classList, { env }) {
-  let classNamesWithOrder = env.context.getClassOrder
-    ? env.context.getClassOrder(classList)
-    : getClassOrderPolyfill(classList, { env })
+  let classNamesWithOrder = reorderClasses(classList, { env })
 
-  return classNamesWithOrder
-    .sort(([, a], [, z]) => {
-      if (a === z) return 0
-      if (a === null) return -1
-      if (z === null) return 1
-      return bigSign(a - z)
-    })
-    .map(([className]) => className)
+  return classNamesWithOrder.map(([className]) => className)
 }

--- a/src/sorting.js
+++ b/src/sorting.js
@@ -161,7 +161,7 @@ export function sortClassList(classList, { env, removeDuplicates }) {
         return false
       }
 
-      // Only considers known classes when removing duplicates
+      // Only consider known classes when removing duplicates
       if (order !== null) {
         seenClasses.add(cls)
       }

--- a/src/sorting.js
+++ b/src/sorting.js
@@ -121,25 +121,31 @@ export function sortClasses(
     suffix = `${whitespace.pop() ?? ''}${classes.pop() ?? ''}`
   }
 
-  classes = sortClassList(classes, { env })
+  let orderedClasses = reorderClasses(classes, { env })
 
   if (removeDuplicates) {
     let seenClasses = new Set()
     let indicesToRemove = new Set()
 
-    classes = classes.filter((cls, index) => {
+    orderedClasses = orderedClasses.filter(([cls, order], index) => {
       if (seenClasses.has(cls)) {
         // Remove the whitespace before the duplicate class
         indicesToRemove.add(index - 1)
         return false
       }
 
-      seenClasses.add(cls)
+      // Only considers known classes when removing duplicates
+      if (order !== null) {
+        seenClasses.add(cls)
+      }
+
       return true
     })
 
     whitespace = whitespace.filter((_, index) => !indicesToRemove.has(index))
   }
+
+  classes = orderedClasses.map(([className]) => className)
 
   for (let i = 0; i < classes.length; i++) {
     result += `${classes[i]}${whitespace[i] ?? ''}`

--- a/src/sorting.js
+++ b/src/sorting.js
@@ -164,7 +164,7 @@ export function sortClasses(
 }
 
 export function sortClassList(classList, { env }) {
-  let orderedClasses = reorderClasses(classList, { env })
+  let classNamesWithOrder = reorderClasses(classList, { env })
 
-  return orderedClasses.map(([className]) => className)
+  return classNamesWithOrder.map(([className]) => className)
 }

--- a/tests/format.test.js
+++ b/tests/format.test.js
@@ -10,6 +10,11 @@ let html = [
   t`<div class=""></div>`,
   // Ensure duplicate classes are removed
   ['<div class="sm:p-0 p-0 p-0"></div>', '<div class="p-0 sm:p-0"></div>'],
+  // Duplicates are not removed for unknown classes
+  [
+    '<div class="idonotexist sm:p-0 p-0 idonotexist p-0 idonotexist"></div>',
+    '<div class="idonotexist idonotexist idonotexist p-0 sm:p-0"></div>',
+  ],
   // Ensure duplicate can be kept
   [
     '<div class="sm:p-0 p-0 p-0"></div>',


### PR DESCRIPTION
### Summary
The change improves the performance of removing duplicated classNames. In this pull request, I replace the indexOf and splice functions, which have O(n) time complexity, with two separate array filters and a Set().

### Comparison
* Before Change: O(n^2) due to the nested indexOf and splice operations within the filter method.

* After Change: O(n) due to the use of a Set for constant-time duplicate checks and separate filtering steps.