### PR TITLE
Use Node 22 in all CI workflows

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18]
+        node-version: [22]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   CI: true
   CACHE_PREFIX: stable
-  NODE_VERSION: 16
+  NODE_VERSION: 22
   RELEASE_CHANNEL: insiders
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   CI: true
   CACHE_PREFIX: stable
-  NODE_VERSION: 16
+  NODE_VERSION: 22
 
 jobs:
   build:


### PR DESCRIPTION
What it says on the tin. Node 16 is well past its EOL.