### PR TITLE
Export plugin options type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1171,7 +1171,7 @@ export const parsers: Record<string, Parser> = {
     : {}),
 }
 
-interface PluginOptions {
+export interface PluginOptions {
   /**
    * Path to the Tailwind config file.
    */


### PR DESCRIPTION
0.6.3 removed the export for the PluginOptions type. This wasn't really intentional so we're adding it back as some projects were importing it.

**However, no project _ever_ needs to use this type directly.**

We extend the appropriate interfaces in Prettier so you only ever have to type your config file export as `import("prettier").Config` or your options object as `import("prettier").Options` if you're using the programmatic API.

Fixes #291
