### PR TITLE
Only re-apply string escaping when necessary

### DIFF
--- a/tests/format.test.js
+++ b/tests/format.test.js
@@ -94,15 +94,9 @@ let javascript = [
     ';<div class={`flex ` + `  ` + `text-red-500`} />',
     ';<div class={`flex ` + ` ` + `text-red-500`} />',
   ],
-  [
-    `;<div class={"before:content-['\\\\2248']"} />`,
-    `;<div class={"before:content-['\\\\2248']"} />`,
-  ],
 
-  [
-    `;<div class={\`before:content-['\\\\2248']\`} />`,
-    `;<div class={\`before:content-['\\\\2248']\`} />`,
-  ],
+  t`;<div class={"before:content-['\\\\2248']"} />`,
+  t`;<div class={\`before:content-['\\\\2248']\`} />`,
 
   [
     `;<div class={'object-cover' + (standalone ? ' aspect-square w-full' : ' min-h-0 grow basis-0')}></div>`,

--- a/tests/format.test.js
+++ b/tests/format.test.js
@@ -97,6 +97,7 @@ let javascript = [
 
   t`;<div class={"before:content-['\\\\2248']"} />`,
   t`;<div class={\`before:content-['\\\\2248']\`} />`,
+  t`;<div class="before:content-['\\\\2248']" />`,
 
   [
     `;<div class={'object-cover' + (standalone ? ' aspect-square w-full' : ' min-h-0 grow basis-0')}></div>`,


### PR DESCRIPTION
In #286 we fixed a situation in which escapes were being stripped from strings. This is because StringLiteral nodes in an expression have both escaped and unescaped values.

However, it seems that some StringLiteral nodes do not do this even though they are otherwise identical. Any StringLiteral that is the direct value of a JSX attribute does not perform any escaping.

For example, given these two JSX nodes, you will get the following as the AST:
```jsx
// The first one
;<div class={"before:content-['\\\\2248']"} />

// The second one
;<div class="before:content-['\\\\2248']" />
```

![image](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/assets/614993/2ae5960d-b74f-4bea-8c60-9990af72d0c9)

So we have to detect whether or not escaping was applied originally before doing that ourselves.

tl;dr software is hard 😅 

Fixes #294
