### PR TITLE
Declare some required dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,22 @@
 {
   "name": "prettier-plugin-tailwindcss",
-  "version": "0.6.3",
+  "version": "0.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prettier-plugin-tailwindcss",
-      "version": "0.6.3",
+      "version": "0.6.5",
       "license": "MIT",
       "devDependencies": {
+        "@babel/types": "^7.24.7",
         "@ianvs/prettier-plugin-sort-imports": "^4.1.0",
         "@microsoft/api-extractor": "^7.47.0",
         "@prettier/plugin-pug": "^3.0",
         "@shopify/prettier-plugin-liquid": "^1.4.0",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
         "@zackad/prettier-plugin-twig-melody": "^0.5.0",
+        "ast-types": "^0.14.2",
         "clear-module": "^4.1.2",
         "cpy-cli": "^5.0.0",
         "esbuild": "^0.19.8",
@@ -442,18 +444,18 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
+      "integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -606,13 +608,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
+      "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -33,12 +33,14 @@
     "release-notes": "node ./scripts/release-notes.js"
   },
   "devDependencies": {
+    "@babel/types": "^7.24.7",
     "@ianvs/prettier-plugin-sort-imports": "^4.1.0",
     "@microsoft/api-extractor": "^7.47.0",
     "@prettier/plugin-pug": "^3.0",
     "@shopify/prettier-plugin-liquid": "^1.4.0",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@zackad/prettier-plugin-twig-melody": "^0.5.0",
+    "ast-types": "^0.14.2",
     "clear-module": "^4.1.2",
     "cpy-cli": "^5.0.0",
     "esbuild": "^0.19.8",


### PR DESCRIPTION
`ast-types` is required (https://github.com/tailwindlabs/prettier-plugin-tailwindcss/blob/efea6f924c2e57fa8f8169231e802466bb5fe9ce/src/index.ts#L6), but isn't declared as a dependency.

When using e.g. `pnpm`, it doesn't get hoisted into `node_modules` from being `recast`'s transitive dependency:

```
$ pnpm why ast-types
Legend: production dependency, optional only, dev only

prettier-plugin-tailwindcss@0.6.5 /Users/akx/build/prettier-plugin-tailwindcss

devDependencies:
recast 0.20.5
└── ast-types 0.14.2
```
so build fails:
```
> node build.mjs --minify

✘ [ERROR] Could not resolve "ast-types"

    src/index.ts:6:26:
      6 │ import * as astTypes from 'ast-types'
```

The same stands for `@babel/types` with a slightly different error (since it's not esbuild but dts complaining).

With these added, things work again:

```
$ git clean -fdx . -e .idea && pnpm i && pnpm build
[...]
Progress: resolved 607, reused 548, downloaded 0, added 548, done
[...]
DTS ⚡️ Build success in 516ms
$
```

