### PR TITLE
fix: zackad/prettier-plugin-twig rename

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -133,7 +133,7 @@ async function loadThirdPartyPlugins(): Promise<PluginDetails> {
     loadIfExistsESM('prettier-plugin-astro'),
     loadIfExistsESM('@shopify/prettier-plugin-liquid'),
     loadIfExistsESM('prettier-plugin-marko'),
-    loadIfExistsESM('@zackad/prettier-plugin-twig-melody'),
+    loadIfExistsESM('@zackad/prettier-plugin-twig'),
     loadIfExistsESM('@prettier/plugin-pug'),
     loadIfExistsESM('prettier-plugin-svelte'),
   ])


### PR DESCRIPTION
https://github.com/zackad/prettier-plugin-twig-melody was renamed to https://github.com/zackad/prettier-plugin-twig