### PR TITLE
Support Tailwind CSS `v4.0.0-alpha.19`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support for `prettier-plugin-multiline-arrays` ([#299](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/299))
 - Add resolution cache for known plugins ([#301](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/301))
+- Support Tailwind CSS `v4.0.0-alpha.19` ([#310](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/310))
 
 ## [0.6.5] - 2024-06-17
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -171,7 +171,11 @@ async function loadV4(
 
   // Load the design system and set up a compatible context object that is
   // usable by the rest of the plugin
-  let design = tw.__unstable__loadDesignSystem(result.css)
+  let design = await tw.__unstable__loadDesignSystem(result.css, {
+    loadPlugin() {
+      return () => {}
+    },
+  })
 
   return {
     context: {


### PR DESCRIPTION
We've made the design system asynchronous and need to account for that. This change is still compatible with previous v4 alphas.