### PR TITLE
Add support for `@plugin` and `@config` in v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Improved performance with large Svelte, Liquid, and Angular files ([#312](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/312))
+- Add support for @plugin and @config in v4 ([#316](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/316))
 
 ## [0.6.6] - 2024-08-09
 

--- a/scripts/install-fixture-deps.js
+++ b/scripts/install-fixture-deps.js
@@ -3,26 +3,23 @@ import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { promisify } from 'node:util'
-
-const execAsync = promisify(exec)
+import glob from 'fast-glob'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-let fixturesDir = path.resolve(__dirname, '../tests/fixtures')
-let fixtureDirs = await fs.readdir(fixturesDir)
-let fixtures = fixtureDirs.map((name) => path.join(fixturesDir, name))
+const fixtures = glob.sync(
+  ['tests/fixtures/*/package.json', 'tests/fixtures/v4/*/package.json'],
+  {
+    cwd: path.resolve(__dirname, '..'),
+  },
+)
+
+const execAsync = promisify(exec)
 
 await Promise.all(
   fixtures.map(async (fixture) => {
-    let exists = await fs.access(path.join(fixture, 'package.json')).then(
-      () => true,
-      () => false,
-    )
-
-    if (!exists) return
-
     console.log(`Installing dependencies for ${fixture}`)
 
-    await execAsync('npm install', { cwd: fixture })
+    await execAsync('npm install', { cwd: path.dirname(fixture) })
   }),
 )

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -1,4 +1,5 @@
 import { createRequire as req } from 'node:module'
+import resolveFrom from 'resolve-from'
 import { expiringMap } from './expiring-map'
 
 const localRequire = req(import.meta.url)
@@ -45,3 +46,5 @@ function freshMaybeResolve(name: string) {
     return null
   }
 }
+
+export { resolveFrom }

--- a/tests/fixtures.test.ts
+++ b/tests/fixtures.test.ts
@@ -62,6 +62,12 @@ let fixtures = [
     dir: 'custom-jsx',
     ext: 'jsx',
   },
+
+  {
+    name: 'v4: basic formatting',
+    dir: 'v4/basic',
+    ext: 'html',
+  },
 ]
 
 let configs = [

--- a/tests/fixtures.test.ts
+++ b/tests/fixtures.test.ts
@@ -68,6 +68,11 @@ let fixtures = [
     dir: 'v4/basic',
     ext: 'html',
   },
+  {
+    name: 'v4: configs and plugins',
+    dir: 'v4/configs',
+    ext: 'html',
+  },
 ]
 
 let configs = [

--- a/tests/fixtures/v4/basic/app.css
+++ b/tests/fixtures/v4/basic/app.css
@@ -1,0 +1,5 @@
+@import 'tailwindcss';
+
+@theme {
+  --color-tomato: tomato;
+}

--- a/tests/fixtures/v4/basic/index.html
+++ b/tests/fixtures/v4/basic/index.html
@@ -1,0 +1,1 @@
+<div class="sm:bg-tomato bg-red-500"></div>

--- a/tests/fixtures/v4/basic/output.html
+++ b/tests/fixtures/v4/basic/output.html
@@ -1,0 +1,1 @@
+<div class="bg-red-500 sm:bg-tomato"></div>

--- a/tests/fixtures/v4/basic/package-lock.json
+++ b/tests/fixtures/v4/basic/package-lock.json
@@ -1,0 +1,17 @@
+{
+  "name": "basic",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "tailwindcss": "^4.0.0-alpha.23"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.0.0-alpha.23",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.23.tgz",
+      "integrity": "sha512-5dy4L1icQUYkG2Fa427QG3fKGkNqMi6V4bJE0DoxBZkR4e550w7uxYJ7vBXINWrRmDd4LHmQInkgsHza3lwONg=="
+    }
+  }
+}

--- a/tests/fixtures/v4/basic/package.json
+++ b/tests/fixtures/v4/basic/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "tailwindcss": "^4.0.0-alpha.23"
+  },
+  "prettier": {
+    "tailwindEntryPoint": "./app.css"
+  }
+}

--- a/tests/fixtures/v4/configs/app.css
+++ b/tests/fixtures/v4/configs/app.css
@@ -1,0 +1,8 @@
+@import "tailwindcss";
+
+@config "./tailwind.config.mjs";
+@plugin "./my-plugin.mjs";
+
+@theme {
+  --color-tomato: tomato;
+}

--- a/tests/fixtures/v4/configs/index.html
+++ b/tests/fixtures/v4/configs/index.html
@@ -1,0 +1,3 @@
+<div
+  class="sm:bg-tomato bg-red-500 from-plugin-1 from-plugin-2 bg-from-config sm:from-plugin-1"
+></div>

--- a/tests/fixtures/v4/configs/my-plugin.mjs
+++ b/tests/fixtures/v4/configs/my-plugin.mjs
@@ -1,0 +1,13 @@
+import plugin from 'tailwindcss/plugin'
+
+export default plugin(function ({ addUtilities }) {
+  addUtilities({
+    '.from-plugin-1': {
+      width: '100%',
+    },
+    '.from-plugin-2': {
+      color: 'red',
+      margin: '2rem',
+    },
+  })
+})

--- a/tests/fixtures/v4/configs/output.html
+++ b/tests/fixtures/v4/configs/output.html
@@ -1,0 +1,3 @@
+<div
+  class="from-plugin-2 from-plugin-1 bg-from-config bg-red-500 sm:from-plugin-1 sm:bg-tomato"
+></div>

--- a/tests/fixtures/v4/configs/package-lock.json
+++ b/tests/fixtures/v4/configs/package-lock.json
@@ -1,0 +1,17 @@
+{
+  "name": "configs",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "tailwindcss": "^4.0.0-alpha.23"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.0.0-alpha.23",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.23.tgz",
+      "integrity": "sha512-5dy4L1icQUYkG2Fa427QG3fKGkNqMi6V4bJE0DoxBZkR4e550w7uxYJ7vBXINWrRmDd4LHmQInkgsHza3lwONg=="
+    }
+  }
+}

--- a/tests/fixtures/v4/configs/package.json
+++ b/tests/fixtures/v4/configs/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "tailwindcss": "^4.0.0-alpha.23"
+  },
+  "prettier": {
+    "tailwindEntryPoint": "./app.css"
+  }
+}

--- a/tests/fixtures/v4/configs/tailwind.config.mjs
+++ b/tests/fixtures/v4/configs/tailwind.config.mjs
@@ -1,0 +1,9 @@
+export default {
+  theme: {
+    extend: {
+      colors: {
+        "from-config": "#3490dc",
+      },
+    },
+  },
+};


### PR DESCRIPTION
Just realized we forgot to add a `loadConfig` stub when we released `v4.0.0-alpha.21`. We also need to actually fill in the implementations of loadPlugin and loadConfig so this PR does that.

We still need to add typescript support which I think means either:
- relying on `@tailwindcss/node` in the prettier plugin; OR
- loading it if it is installed

I'm not actually sure which option we should go with so I've not added typescript support yet.