### PR TITLE
Fix crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+- Fix crash ([#320](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/320))
 
 ## [0.6.7] - 2024-09-24
 

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -40,8 +40,13 @@ export function maybeResolve(name: string) {
   let modpath = resolveCache.get(name)
 
   if (modpath === undefined) {
-    modpath = resolveJsFrom(fileURLToPath(import.meta.url), name)
-    resolveCache.set(name, modpath)
+    try {
+      modpath = resolveJsFrom(fileURLToPath(import.meta.url), name)
+      resolveCache.set(name, modpath)
+    } catch (err) {
+      resolveCache.set(name, null)
+      return null
+    }
   }
 
   return modpath


### PR DESCRIPTION
We forgot a try/catch when we switched to `enhanced-resolve` for dynamic dependency loading. Oops…