### PR TITLE
Add missing properties to PluginOptions type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support for `@zackad/prettier-plugin-twig` ([#308](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/308))
 - Dropped support for `@zackad/prettier-plugin-twig-melody` ([#308](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/308))
+- Updated Prettier options types ([#325](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/325))
 
 ## [0.6.9] - 2024-11-19
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1210,6 +1210,16 @@ export interface PluginOptions {
    * List of custom attributes that contain classes.
    */
   tailwindAttributes?: string[]
+
+  /**
+   * Preserve whitespace around Tailwind classes when sorting.
+   */
+  tailwindPreserveWhitespace?: boolean
+
+  /**
+   * Preserve duplicate classes inside a class list when sorting.
+   */
+  tailwindPreserveDuplicates?: boolean
 }
 
 declare module 'prettier' {


### PR DESCRIPTION
Properties `tailwindPreserveWhitespace` and `tailwindPreserveDuplicates` are defined in [options.ts](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/blob/64373cf9c4edb260bb482a0a55b65230df3d1e8b/src/options.ts#L36-L48) but not in `PluginOptions` type.
Although these options are configurable, they didn't appear as suggestions when editing Prettier configuration.