### PR TITLE
Introduce `tailwindStylesheet` option to replace `tailwindEntryPoint`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ As of v0.5.x, this plugin now requires Prettier v3 and is ESM-only. This means i
 
 ## Options
 
-### Using with Tailwind CSS v4.0
+### Specifying your Tailwind stylesheet path
 
 When using Tailwind CSS v4 you must specify your CSS file entry point, which includes your theme, custom utilities, and other Tailwind configuration options. To do this, use the `tailwindStylesheet` option in your Prettier configuration.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ As of v0.5.x, this plugin now requires Prettier v3 and is ESM-only. This means i
 
 ### Using with Tailwind CSS v4.0
 
-When using Tailwind CSS v4 you must specify what CSS file we should use that contains your theme, custom utilities, etc… To do this use the `tailwindStylesheet` option in your Prettier configuration.
+When using Tailwind CSS v4 you must specify your CSS file entry point, which includes your theme, custom utilities, and other Tailwind configuration options. To do this, use the `tailwindStylesheet` option in your Prettier configuration.
 
 Note that paths are resolved relative to the Prettier configuration file.
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ Note that paths are resolved relative to the Prettier configuration file.
 }
 ```
 
-Note: this option was previously named `tailwindEntryPoint` it has been renamed to better reflect its purpose.
-
 ### Customizing your Tailwind config path
 
 To ensure that the class sorting takes into consideration any of your project's Tailwind customizations, it needs access to your [Tailwind configuration file](https://tailwindcss.com/docs/configuration) (`tailwind.config.js`).

--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ As of v0.5.x, this plugin now requires Prettier v3 and is ESM-only. This means i
 
 ## Options
 
+### Using with Tailwind CSS v4.0
+
+When using Tailwind CSS v4 you must specify what CSS file we should use that contains your theme, custom utilities, etc… To do this use the `tailwindStylesheet` option in your Prettier configuration.
+
+Note that paths are resolved relative to the Prettier configuration file.
+
+```json5
+// .prettierrc
+{
+  "tailwindStylesheet": "./resources/css/app.css"
+}
+```
+
+Note: this option was previously named `tailwindEntryPoint` it has been renamed to better reflect its purpose.
+
 ### Customizing your Tailwind config path
 
 To ensure that the class sorting takes into consideration any of your project's Tailwind customizations, it needs access to your [Tailwind configuration file](https://tailwindcss.com/docs/configuration) (`tailwind.config.js`).

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Note that paths are resolved relative to the Prettier configuration file.
 }
 ```
 
-### Customizing your Tailwind config path
+### Specifying your Tailwind JavaScript config path
 
 To ensure that the class sorting takes into consideration any of your project's Tailwind customizations, it needs access to your [Tailwind configuration file](https://tailwindcss.com/docs/configuration) (`tailwind.config.js`).
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -335,10 +335,18 @@ function getEntryPoint(options: ParserOptions, baseDir: string): string | null {
   }
 
   if (options.tailwindEntryPoint) {
+    console.warn(
+      'Use the `tailwindStylesheet` option for v4 projects instead of `tailwindEntryPoint`.',
+    )
+
     return path.resolve(baseDir, options.tailwindEntryPoint)
   }
 
   if (options.tailwindConfig && options.tailwindConfig.endsWith('.css')) {
+    console.warn(
+      'Use the `tailwindStylesheet` option for v4 projects instead of `tailwindConfig`.',
+    )
+
     return path.resolve(baseDir, options.tailwindConfig)
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -297,6 +297,10 @@ async function loadV4(
 
 function getConfigPath(options: ParserOptions, baseDir: string): string | null {
   if (options.tailwindConfig) {
+    if (options.tailwindConfig.endsWith('.css')) {
+      return null
+    }
+
     return path.resolve(baseDir, options.tailwindConfig)
   }
 
@@ -332,6 +336,10 @@ function getEntryPoint(options: ParserOptions, baseDir: string): string | null {
 
   if (options.tailwindEntryPoint) {
     return path.resolve(baseDir, options.tailwindEntryPoint)
+  }
+
+  if (options.tailwindConfig && options.tailwindConfig.endsWith('.css')) {
+    return path.resolve(baseDir, options.tailwindConfig)
   }
 
   return null

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,7 @@ export async function getTailwindConfig(
 ): Promise<ContextContainer> {
   let key = [
     options.filepath,
+    options.tailwindStylesheet ?? '',
     options.tailwindEntryPoint ?? '',
     options.tailwindConfig ?? '',
   ].join(':')
@@ -325,6 +326,10 @@ function getConfigPath(options: ParserOptions, baseDir: string): string | null {
 }
 
 function getEntryPoint(options: ParserOptions, baseDir: string): string | null {
+  if (options.tailwindStylesheet) {
+    return path.resolve(baseDir, options.tailwindStylesheet)
+  }
+
   if (options.tailwindEntryPoint) {
     return path.resolve(baseDir, options.tailwindEntryPoint)
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,7 +28,11 @@ let prettierConfigCache = expiringMap<string, string | null>(10_000)
 export async function getTailwindConfig(
   options: ParserOptions,
 ): Promise<ContextContainer> {
-  let key = `${options.filepath}:${options.tailwindConfig ?? ''}:${options.tailwindEntryPoint ?? ''}`
+  let key = [
+    options.filepath,
+    options.tailwindEntryPoint ?? '',
+    options.tailwindConfig ?? '',
+  ].join(':')
   let baseDir = await getBaseDir(options)
 
   // Map the source file to it's associated Tailwind config file

--- a/src/index.ts
+++ b/src/index.ts
@@ -1197,7 +1197,14 @@ export interface PluginOptions {
   tailwindConfig?: string
 
   /**
-   * Path to the Tailwind entry point (v4+)
+   * Path to the CSS stylesheet used by Tailwind CSS (v4+)
+   */
+  tailwindStylesheet?: string
+
+  /**
+   * Path to the CSS stylesheet used by Tailwind CSS (v4+)
+   *
+   * @deprecated Use `tailwindStylesheet` instead
    */
   tailwindEntryPoint?: string
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -13,6 +13,15 @@ export const options: Record<string, SupportOption> = {
     type: 'string',
     category: 'Tailwind CSS',
     description: 'Path to the CSS entrypoint in your Tailwind project (v4+)',
+
+    // Can't include this otherwise the option is not passed to parsers
+    // deprecated: "This option is deprecated. Use 'tailwindStylesheet' instead.",
+  },
+
+  tailwindStylesheet: {
+    type: 'string',
+    category: 'Tailwind CSS',
+    description: 'Path to the CSS stylesheet in your Tailwind project (v4+)',
   },
 
   tailwindAttributes: {

--- a/tests/fixtures/v4/basic/package-lock.json
+++ b/tests/fixtures/v4/basic/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "tailwindcss": "^4.0.0-alpha.23"
+        "tailwindcss": "^4.0.0-alpha.34"
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.0.0-alpha.23",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.23.tgz",
-      "integrity": "sha512-5dy4L1icQUYkG2Fa427QG3fKGkNqMi6V4bJE0DoxBZkR4e550w7uxYJ7vBXINWrRmDd4LHmQInkgsHza3lwONg=="
+      "version": "4.0.0-alpha.34",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.34.tgz",
+      "integrity": "sha512-SST1h774z+bVCLTpRz4TYpjJLIcomZH1HBF4OPY1YusONUYqg0/XTq0N++12mNeyu6mK7VbFIkkNtf636yudWQ=="
     }
   }
 }

--- a/tests/fixtures/v4/basic/package.json
+++ b/tests/fixtures/v4/basic/package.json
@@ -3,6 +3,6 @@
     "tailwindcss": "^4.0.0-alpha.34"
   },
   "prettier": {
-    "tailwindEntryPoint": "./app.css"
+    "tailwindStylesheet": "./app.css"
   }
 }

--- a/tests/fixtures/v4/basic/package.json
+++ b/tests/fixtures/v4/basic/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "tailwindcss": "^4.0.0-alpha.23"
+    "tailwindcss": "^4.0.0-alpha.34"
   },
   "prettier": {
     "tailwindEntryPoint": "./app.css"

--- a/tests/fixtures/v4/configs/package-lock.json
+++ b/tests/fixtures/v4/configs/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "tailwindcss": "^4.0.0-alpha.23"
+        "tailwindcss": "^4.0.0-alpha.34"
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.0.0-alpha.23",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.23.tgz",
-      "integrity": "sha512-5dy4L1icQUYkG2Fa427QG3fKGkNqMi6V4bJE0DoxBZkR4e550w7uxYJ7vBXINWrRmDd4LHmQInkgsHza3lwONg=="
+      "version": "4.0.0-alpha.34",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.34.tgz",
+      "integrity": "sha512-SST1h774z+bVCLTpRz4TYpjJLIcomZH1HBF4OPY1YusONUYqg0/XTq0N++12mNeyu6mK7VbFIkkNtf636yudWQ=="
     }
   }
 }

--- a/tests/fixtures/v4/configs/package.json
+++ b/tests/fixtures/v4/configs/package.json
@@ -3,6 +3,6 @@
     "tailwindcss": "^4.0.0-alpha.34"
   },
   "prettier": {
-    "tailwindEntryPoint": "./app.css"
+    "tailwindStylesheet": "./app.css"
   }
 }

--- a/tests/fixtures/v4/configs/package.json
+++ b/tests/fixtures/v4/configs/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "tailwindcss": "^4.0.0-alpha.23"
+    "tailwindcss": "^4.0.0-alpha.34"
   },
   "prettier": {
     "tailwindEntryPoint": "./app.css"


### PR DESCRIPTION
We're replacing the existing `tailwindEntryPoint` option with a `tailwindStylesheet` option. The existing option is just not well named and the new one feels more correct.

Some notes:
- The existing option **still works** it's just deprecated
- We'll warn when a user is using `tailwindEntryPoint` and instruct them to use `tailwindStylesheet` instead
- You may also specify the path to a CSS file in `tailwindConfig` and it'll _just work_ in a v4 project. Note: This will also warn users to use `tailwindStylesheet` but it seems like the principle of least surprise to make it work and instruct users on how to upgrade.

Fixes #318