### PR TITLE
Fix erroneous template string whitespace formatting in Svelte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for `@zackad/prettier-plugin-twig` ([#308](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/308))
 - Dropped support for `@zackad/prettier-plugin-twig-melody` ([#308](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/308))
 - Updated Prettier options types ([#325](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/325))
+- Don't remove whitespace inside template literals in Svelte ([#332](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/332))
 
 ## [0.6.9] - 2024-11-19
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -537,7 +537,7 @@ function sortTemplateLiteral(
       // And does not end with a space
       ignoreLast: i < node.expressions.length && !/\s$/.test(quasi.value.raw),
 
-      collapseWhitespace: {
+      collapseWhitespace: collapseWhitespace && {
         start: collapseWhitespace && collapseWhitespace.start && i === 0,
         end:
           collapseWhitespace &&
@@ -553,7 +553,7 @@ function sortTemplateLiteral(
           ignoreFirst: i > 0 && !/^\s/.test(quasi.value.cooked),
           ignoreLast:
             i < node.expressions.length && !/\s$/.test(quasi.value.cooked),
-          collapseWhitespace: {
+          collapseWhitespace: collapseWhitespace && {
             start: collapseWhitespace && collapseWhitespace.start && i === 0,
             end:
               collapseWhitespace &&

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -415,7 +415,6 @@ import Custom from '../components/Custom.astro'
           `<div class="sm:p-0 p-0 {someVar}sm:block md:inline flex" />`,
           `<div class="p-0 sm:p-0 {someVar}sm:block flex md:inline" />`,
         ],
-        ['<div class={`sm:p-0\np-0`} />', '<div class={`p-0 sm:p-0`} />'],
         t`{#await promise()} <div class="${yes}" /> {:then} <div class="${yes}" /> {/await}`,
         t`{#await promise() then} <div class="${yes}" /> {/await}`,
 
@@ -435,6 +434,12 @@ import Custom from '../components/Custom.astro'
 
         // Escapes
         t`<div class={"before:content-['\\\\2248']"}></div>`,
+
+        // Preserve whitespace in template strings
+        [
+          `<div class={\`underline  flex\`}></div>`,
+          `<div class={\`flex  underline\`}></div>`,
+        ],
       ],
     },
   },

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -436,9 +436,12 @@ import Custom from '../components/Custom.astro'
         t`<div class={"before:content-['\\\\2248']"}></div>`,
 
         // Preserve whitespace in template strings
+        // This test has lots of whitespace to ensure that the Svelte
+        // parser doesn't produce invalid syntax as output since it breaks
+        // when changing the length of the text.
         [
-          `<div class={\`underline  flex\`}></div>`,
-          `<div class={\`flex  underline\`}></div>`,
+          `<div\n class={\`underline \n flex\`}></div>`,
+          `<div\n  class={\`flex \n underline\`}\n></div>`,
         ],
       ],
     },


### PR DESCRIPTION
## Overview

We've been using `prettier-plugin-tailwindcss` to great effect in various Svelte projects at work, but after updating to `v0.6.x`, we noticed that Svelte components with template string classnames using newlines starting printing with **invalid syntax**, even when no class re-ordering was necessary

```svelte
<!-- input -->
<div
  class={`flex
          h-7.5`}
></div>
```

```svelte
<!-- output, invalid syntax -->
<div class={`flex h-7.5`}
></div>}></div>
```

Previously reported as #303

## Cause

I dug into the code, and noticed that inside the Svelte template string formatter, there is this call:

```ts
let sorted = sortTemplateLiteral(node, {
  env,
  removeDuplicates: false,
  collapseWhitespace: false,
})
```

From this call, and from reading some of the tests, it definitely seemed like the intent was to avoid collapsing whitespace in Svelte template literals. Despite this apparent intent, digging further, I found `collapseWhitespace` option of `sortTemplateLiteral` was effectively ignored, because:

```ts
{ collapseWhitespace: false }
```

Was getting turned into:

```ts
{ collapseWhitespace: { start: false, end: false } }
```

Before being passed to `sortClasses`. This is not equivalent according to the internal logic of `sortClasses`. From there, there appears to be some sort of re-printing bug in `prettier-plugin-svelte`, which I did not dig into further

## Fix

Inside `sortTemplateLiteral`, I added extra short-circuits to ensure `collapseWhitespace: false` is preserved. Preserving whitespace in template strings happily avoids whatever re-printing bug(s) exists in the Svelte plugin, and feels fairly "correct" to me because template strings intentionally preserve newlines etc.