### PR TITLE
doc: add `pnpm` installation alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ To get started, install `prettier-plugin-tailwindcss` as a dev-dependency:
 npm install -D prettier prettier-plugin-tailwindcss
 ```
 
+<details>
+<summary>Installation with pnpm</summary>
+
+```shell
+pnpm add -D prettier prettier-plugin-tailwindcss
+```
+</details>
+
 Then add the plugin to your [Prettier configuration](https://prettier.io/docs/en/configuration.html):
 
 ```json5


### PR DESCRIPTION
This PR adds a section to the `README.md` to install the package with `pnpm` as an alternative.