### PR TITLE
fix: remove unused import in script

### DIFF
--- a/scripts/install-fixture-deps.js
+++ b/scripts/install-fixture-deps.js
@@ -1,5 +1,4 @@
 import { exec } from 'node:child_process'
-import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { promisify } from 'node:util'


### PR DESCRIPTION
This pull request includes a small change to the `scripts/install-fixture-deps.js` file. The change removes an unused import statement for `fs` from the Node.js `promises` module.