### PR TITLE
Remove `declare` to clean up global scope

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1228,8 +1228,3 @@ export interface PluginOptions {
    */
   tailwindPreserveDuplicates?: boolean
 }
-
-declare module 'prettier' {
-  interface RequiredOptions extends PluginOptions {}
-  interface ParserOptions extends PluginOptions {}
-}


### PR DESCRIPTION
# Description

As described [in the issue I filed](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/issues/339), this `declare` statement is polluting the global scope. It's providing autocomplete in `prettier.config.js` files, but offers no real type safety. For instance, if you install the plugin but never add it to your `plugins`, the tailwind options will appear and cause a config error.

Importing the types like this is far safer.
```js
/** @type {import('prettier').Config & import('prettier-plugin-tailwindcss').PluginOptions} */
```

You might consider this a breaking change, but I don't think a major is necessary. Since there's no actual type-checking in .js files, this shouldn't cause any errors. You'd just lose out on intellisense until you imported the type above. Users with a .json config won't notice anything at all.