### PR TITLE
🛠️Normalize test line endings

### DIFF
--- a/tests/fixtures.test.ts
+++ b/tests/fixtures.test.ts
@@ -8,8 +8,8 @@ import { format, pluginPath } from './utils'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
-
 const execAsync = promisify(exec)
+const normalizeLineEndings = (text: string) => text.replace(/\r\n/g, '\n')
 
 let fixtures = [
   {
@@ -114,8 +114,6 @@ describe('fixtures', () => {
     let inputPath = path.resolve(fixturePath, `index.${ext}`)
     let outputPath = path.resolve(fixturePath, `output.${ext}`)
     let cmd = `${binPath} ${inputPath} --plugin ${pluginPath}`
-
-    const normalizeLineEndings = (text: string) => text.replace(/\r\n/g, '\n')
 
     test.concurrent(name, async ({ expect }) => {
       let results = await execAsync(cmd)

--- a/tests/fixtures.test.ts
+++ b/tests/fixtures.test.ts
@@ -115,10 +115,12 @@ describe('fixtures', () => {
     let outputPath = path.resolve(fixturePath, `output.${ext}`)
     let cmd = `${binPath} ${inputPath} --plugin ${pluginPath}`
 
+    const normalizeLineEndings = (text: string) => text.replace(/\r\n/g, '\n')
+
     test.concurrent(name, async ({ expect }) => {
       let results = await execAsync(cmd)
-      let formatted = results.stdout
-      let expected = await fs.readFile(outputPath, 'utf-8')
+      let formatted = normalizeLineEndings(results.stdout)
+      let expected = normalizeLineEndings(await fs.readFile(outputPath, 'utf-8'))
 
       expect(formatted.trim()).toEqual(expected.trim())
     })

--- a/tests/fixtures.test.ts
+++ b/tests/fixtures.test.ts
@@ -9,7 +9,6 @@ import { format, pluginPath } from './utils'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const execAsync = promisify(exec)
-const normalizeLineEndings = (text: string) => text.replace(/\r\n/g, '\n')
 
 let fixtures = [
   {
@@ -117,8 +116,10 @@ describe('fixtures', () => {
 
     test.concurrent(name, async ({ expect }) => {
       let results = await execAsync(cmd)
-      let formatted = normalizeLineEndings(results.stdout)
-      let expected = normalizeLineEndings(await fs.readFile(outputPath, 'utf-8'))
+      let formatted = results.stdout.replace(/\r\n/g, '\n')
+      let expected = await fs
+        .readFile(outputPath, 'utf-8')
+        .then((c) => c.replace(/\r\n/g, '\n'))
 
       expect(formatted.trim()).toEqual(expected.trim())
     })


### PR DESCRIPTION
# Line Endings Normalization in Fixture Tests

## Description
Added line endings normalization to fixture tests to ensure consistent comparison between expected and actual outputs across different operating systems.

## Problem
![image](https://github.com/user-attachments/assets/3c67a183-0960-4bd9-a46f-7b3a641fcd8c)
Test fixtures could fail when run on different operating systems (particularly Windows vs Unix-based systems) due to inconsistent line endings (`\r\n` vs `\n`). This caused false negatives in the test suite when the only difference was the line ending style.

## Solution
Added a `normalizeLineEndings` function that converts all Windows-style line endings (`\r\n`) to Unix-style (`\n`) before comparing test outputs. This ensures that:
- Tests are reliable across all operating systems
- Git's automatic line ending conversion doesn't affect test results
- We're testing the actual content formatting rather than platform-specific line endings

## Testing
- Verified tests pass on both Windows and Unix-based systems
- Confirmed that the normalization doesn't affect the actual plugin output
- Existing test cases remain unchanged in their assertions