### PR TITLE
fix: prevent Svelte files from breaking when there are duplicate classes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -557,6 +557,7 @@ function sortTemplateLiteral(
           ignoreFirst: i > 0 && !/^\s/.test(quasi.value.cooked),
           ignoreLast:
             i < node.expressions.length && !/\s$/.test(quasi.value.cooked),
+          removeDuplicates,
           collapseWhitespace: collapseWhitespace && {
             start: collapseWhitespace && collapseWhitespace.start && i === 0,
             end:

--- a/src/index.ts
+++ b/src/index.ts
@@ -454,6 +454,7 @@ function sortStringLiteral(
   node: any,
   {
     env,
+    removeDuplicates,
     collapseWhitespace = { start: true, end: true },
   }: {
     env: TransformerEnv
@@ -463,6 +464,7 @@ function sortStringLiteral(
 ) {
   let result = sortClasses(node.value, {
     env,
+    removeDuplicates,
     collapseWhitespace,
   })
   let didChange = result !== node.value
@@ -513,6 +515,7 @@ function sortTemplateLiteral(
   node: any,
   {
     env,
+    removeDuplicates,
     collapseWhitespace = { start: true, end: true },
   }: {
     env: TransformerEnv
@@ -530,6 +533,7 @@ function sortTemplateLiteral(
 
     quasi.value.raw = sortClasses(quasi.value.raw, {
       env,
+      removeDuplicates,
       // Is not the first "item" and does not start with a space
       ignoreFirst: i > 0 && !/^\s/.test(quasi.value.raw),
 
@@ -946,7 +950,7 @@ function transformSvelte(ast: any, { env, changes }: TransformerContext) {
           env,
           ignoreFirst: i > 0 && !/^\s/.test(value.raw),
           ignoreLast: i < attr.value.length - 1 && !/\s$/.test(value.raw),
-          removeDuplicates: false,
+          removeDuplicates: true,
           collapseWhitespace: false,
         })
         value.data = same
@@ -955,7 +959,7 @@ function transformSvelte(ast: any, { env, changes }: TransformerContext) {
               env,
               ignoreFirst: i > 0 && !/^\s/.test(value.data),
               ignoreLast: i < attr.value.length - 1 && !/\s$/.test(value.data),
-              removeDuplicates: false,
+              removeDuplicates: true,
               collapseWhitespace: false,
             })
       } else if (value.type === 'MustacheTag') {

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -444,6 +444,26 @@ import Custom from '../components/Custom.astro'
           `<div\n class={\`underline \n flex\`}></div>`,
           `<div\n  class={\`flex \n underline\`}\n></div>`,
         ],
+        [
+          `<div class="flex underline flex"></div>`,
+          `<div class="flex underline"></div>`,
+        ],
+
+        // Remove duplicates in Svelte text case:
+        [
+          `<div class="flex flex underline flex flex"></div>`,
+          `<div class="flex underline"></div>`,
+        ],
+        // Svelte literal case (project doesn't break with duplicates):
+        [
+          `<div class={'flex underline flex'}></div>`,
+          `<div class={'flex flex underline'}></div>`,
+        ],
+        // Svelte string literal case (project doesn't break with duplicates);
+        [
+          `<div class={\`flex underline flex\`}></div>`,
+          `<div class={\`flex flex underline\`}></div>`,
+        ],
       ],
     },
   },

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -444,10 +444,6 @@ import Custom from '../components/Custom.astro'
           `<div\n class={\`underline \n flex\`}></div>`,
           `<div\n  class={\`flex \n underline\`}\n></div>`,
         ],
-        [
-          `<div class="flex underline flex"></div>`,
-          `<div class="flex underline"></div>`,
-        ],
 
         // Remove duplicates in Svelte text case:
         [


### PR DESCRIPTION
As of v0.6.11, Svelte files still break after saving a file that contains duplicate classes in template strings. 

This seems to be because of a bug where there are certain times `transformSvelte` results in calls to `sortClasses` that don't pass `removeDuplicates` at all, but `sortClasses` defaults it to true, resulting in the plugin attempting to remove duplicates even though this is not supported yet in Svelte.

Now, we pass `removeDuplicates` in all cases. In the case of string literals, this results in the classes being sorted with the duplicates remaining (without breaking your project). Getting the functionality of removing duplicates removed in string literals requires more work. 

However, it seems that removing duplicates in the normal "text" (non-literal) case works totally fine in Svelte, so I decided to enable removing duplicates in that case. Added some new tests with duplicates in the 3 different cases that all pass. 

Thanks to @onsclom for helping on this! 