### PR TITLE
fix: enforce compatible plugins load order for proper interoperability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Prevent Svelte files from breaking when there are duplicate classes ([#359](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/359))
+- Ensure `prettier-plugin-multiline-arrays` and `prettier-plugin-jsdoc` work used together with this plugin ([#372](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/372))
 
 ## [0.6.12] - 2025-05-30
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "ast-types": "^0.14.2",
         "clear-module": "^4.1.2",
         "cpy-cli": "^5.0.0",
+        "dedent": "^1.6.0",
         "enhanced-resolve": "^5.17.1",
         "esbuild": "^0.19.8",
         "escalade": "^3.1.1",
@@ -2935,6 +2936,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
+      "integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
       }
     },
     "node_modules/deep-eql": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "ast-types": "^0.14.2",
     "clear-module": "^4.1.2",
     "cpy-cli": "^5.0.0",
+    "dedent": "^1.6.0",
     "enhanced-resolve": "^5.17.1",
     "esbuild": "^0.19.8",
     "escalade": "^3.1.1",

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -128,7 +128,6 @@ async function loadBuiltinPlugins(): Promise<PluginDetails> {
 }
 
 async function loadThirdPartyPlugins(): Promise<PluginDetails> {
-  // Commented out plugins do not currently work with Prettier v3.0
   let [astro, liquid, marko, twig, pug, svelte] = await Promise.all([
     loadIfExistsESM('prettier-plugin-astro'),
     loadIfExistsESM('@shopify/prettier-plugin-liquid'),
@@ -153,18 +152,18 @@ async function loadThirdPartyPlugins(): Promise<PluginDetails> {
 }
 
 async function loadCompatiblePlugins() {
-  // Commented out plugins do not currently work with Prettier v3.0
+  // Plugins are loaded in a specific order for proper interoperability
   let plugins = [
-    '@ianvs/prettier-plugin-sort-imports',
-    '@trivago/prettier-plugin-sort-imports',
-    'prettier-plugin-organize-imports',
     'prettier-plugin-css-order',
-    'prettier-plugin-import-sort',
-    'prettier-plugin-jsdoc',
-    'prettier-plugin-multiline-arrays',
     'prettier-plugin-organize-attributes',
     'prettier-plugin-style-order',
+    'prettier-plugin-multiline-arrays',
+    '@ianvs/prettier-plugin-sort-imports',
+    '@trivago/prettier-plugin-sort-imports',
+    'prettier-plugin-import-sort',
+    'prettier-plugin-organize-imports',
     'prettier-plugin-sort-imports',
+    'prettier-plugin-jsdoc',
   ]
 
   // Load all the available compatible plugins up front

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -157,12 +157,19 @@ async function loadCompatiblePlugins() {
     'prettier-plugin-css-order',
     'prettier-plugin-organize-attributes',
     'prettier-plugin-style-order',
+
+    // The following plugins must come *before* the jsdoc plugin for it to
+    // function correctly. Additionally `multiline-arrays` usually needs to be
+    // placed before import sorting plugins.
+    //
+    // https://github.com/electrovir/prettier-plugin-multiline-arrays#compatibility
     'prettier-plugin-multiline-arrays',
     '@ianvs/prettier-plugin-sort-imports',
     '@trivago/prettier-plugin-sort-imports',
     'prettier-plugin-import-sort',
     'prettier-plugin-organize-imports',
     'prettier-plugin-sort-imports',
+
     'prettier-plugin-jsdoc',
   ]
 

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -469,15 +469,30 @@ import Custom from '../components/Custom.astro'
     },
   },
 
+  // This test ensures that our plugin works with the multiline array, JSDoc,
+  // and import sorting plugins when used together.
+  //
+  // The plugins actually have to be *imported* in a specific order for
+  // them to function correctly *together*.
   {
-    plugins: ['prettier-plugin-multiline-arrays', 'prettier-plugin-jsdoc'],
+    plugins: [
+      'prettier-plugin-multiline-arrays',
+      '@trivago/prettier-plugin-sort-imports',
+      'prettier-plugin-jsdoc',
+    ],
     options: {
       multilineArraysWrapThreshold: 0,
+      importOrder: ['^@one/(.*)$', '^@two/(.*)$', '^[./]'],
+      importOrderSortSpecifiers: true,
     },
     tests: {
-      typescript: [
+      babel: [
         [
           dedent`
+            import './three'
+            import '@two/file'
+            import '@one/file'
+
             /**
               * - Position
               */
@@ -485,6 +500,10 @@ import Custom from '../components/Custom.astro'
             const arr = ['a', 'b', 'c', 'd', 'e', 'f']
           `,
           dedent`
+            import '@one/file'
+            import '@two/file'
+            import './three'
+
             /** - Position */
             const position = {}
             const arr = [

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module'
+import dedent from 'dedent'
 import { test } from 'vitest'
 import type { TestEntry } from './utils.js'
 import { format, no, pluginPath, t, yes } from './utils.js'
@@ -463,6 +464,38 @@ import Custom from '../components/Custom.astro'
         [
           `<div class={\`flex underline flex\`}></div>`,
           `<div class={\`flex flex underline\`}></div>`,
+        ],
+      ],
+    },
+  },
+
+  {
+    plugins: ['prettier-plugin-multiline-arrays', 'prettier-plugin-jsdoc'],
+    options: {
+      multilineArraysWrapThreshold: 0,
+    },
+    tests: {
+      typescript: [
+        [
+          dedent`
+            /**
+              * - Position
+              */
+            const position = {}
+            const arr = ['a', 'b', 'c', 'd', 'e', 'f']
+          `,
+          dedent`
+            /** - Position */
+            const position = {}
+            const arr = [
+              'a',
+              'b',
+              'c',
+              'd',
+              'e',
+              'f',
+            ]
+          `,
         ],
       ],
     },


### PR DESCRIPTION
Hi, Tailwind Team!
Thank you for the awesome plugin!

## Overview

This PR updates the load order of plugins compatible with `prettier-plugin-tailwindcss` for proper interoperability.

It also removes the obsolete comment about plugins commented out due to incompatibility with Prettier 3.0.

### 🧐 The Problem

Certain Prettier plugins, like `prettier-plugin-multiline-arrays`, may cause conflicts or unexpected behavior when loaded in the wrong order, leading to formatting issues or plugin failures.

In my case, `prettier-plugin-jsdoc` fails to apply its formatting when used with both `prettier-plugin-multiline-arrays` and `prettier-plugin-tailwindcss`, but works correctly when `prettier-plugin-tailwindcss` is excluded and the plugin order is properly set.

### 💡 The Solution

The [`loadCompatiblePlugins`](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/blob/03dd9a56b77e8d23b697f3d43c616f8d5f5a68ac/src/plugins.ts#L155) function has been updated to enforce a specific plugin load order for proper interoperability. The updated code includes a curated list of plugins with a defined sequence.

### ✔️ Testing

Due to time constraints, I performed only initial testing using the [`pnpm patch`](https://pnpm.io/cli/patch) feature with the following Prettier configuration:

```ts
/** @type {import("prettier").Config} */
export default {
  multilineArraysWrapThreshold: 0,
  plugins: [
    "prettier-plugin-multiline-arrays",
    "prettier-plugin-jsdoc",
    "prettier-plugin-tailwindcss",
  ],
};
```

The changes resolved the formatting issue between these plugins in my local setup.

> [!WARNING]
> I’d greatly appreciate it if someone could conduct more comprehensive testing to confirm the plugin load order ensures compatibility across all supported plugins. Although, I plan to conduct additional testing myself when time permits.

### 🔖 Additional Info

1. [Plugin load order recommendations for `prettier-plugin-multiline-arrays` compatibility](https://github.com/electrovir/prettier-plugin-multiline-arrays?tab=readme-ov-file#compatibility)
2. [Issue discussing the load order of `prettier-plugin-jsdoc` and `@ianvs/prettier-plugin-sort-imports` plugins when used with `prettier-plugin-multiline-arrays`](https://github.com/electrovir/prettier-plugin-multiline-arrays/issues/40#issuecomment-2242146203)

Looking forward to your review and feedback.
Thanks! 🫶