### PR TITLE
Drop support for `prettier-plugin-import-sort`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Don't augment global Prettier `ParserOptions` and `RequiredOptions` types ([#354](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/354))
+- Drop support for `prettier-plugin-import-sort` ([#385](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/385))
 
 ## [0.6.14] - 2025-07-09
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,6 @@ This plugin uses Prettier APIs that can only be used by one plugin at a time, ma
 - `@trivago/prettier-plugin-sort-imports`
 - `prettier-plugin-astro`
 - `prettier-plugin-css-order`
-- `prettier-plugin-import-sort`
 - `prettier-plugin-jsdoc`
 - `prettier-plugin-multiline-arrays`
 - `prettier-plugin-organize-attributes`

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "prettier": "^3.6",
         "prettier-plugin-astro": "^0.14.1",
         "prettier-plugin-css-order": "^2.0.0",
-        "prettier-plugin-import-sort": "^0.0.7",
         "prettier-plugin-jsdoc": "^1.3.3",
         "prettier-plugin-marko": "^3.3.0",
         "prettier-plugin-multiline-arrays": "^4.0.3",
@@ -68,7 +67,6 @@
         "prettier": "^3.0",
         "prettier-plugin-astro": "*",
         "prettier-plugin-css-order": "*",
-        "prettier-plugin-import-sort": "*",
         "prettier-plugin-jsdoc": "*",
         "prettier-plugin-marko": "*",
         "prettier-plugin-multiline-arrays": "*",
@@ -104,9 +102,6 @@
           "optional": true
         },
         "prettier-plugin-css-order": {
-          "optional": true
-        },
-        "prettier-plugin-import-sort": {
           "optional": true
         },
         "prettier-plugin-jsdoc": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "prettier": "^3.6.2",
     "prettier-plugin-astro": "^0.14.1",
     "prettier-plugin-css-order": "^2.1.2",
-    "prettier-plugin-import-sort": "^0.0.7",
     "prettier-plugin-jsdoc": "^1.3.3",
     "prettier-plugin-marko": "^3.3.0",
     "prettier-plugin-multiline-arrays": "^4.0.3",
@@ -89,7 +88,6 @@
     "prettier": "^3.0",
     "prettier-plugin-astro": "*",
     "prettier-plugin-css-order": "*",
-    "prettier-plugin-import-sort": "*",
     "prettier-plugin-jsdoc": "*",
     "prettier-plugin-marko": "*",
     "prettier-plugin-multiline-arrays": "*",
@@ -125,9 +123,6 @@
       "optional": true
     },
     "prettier-plugin-css-order": {
-      "optional": true
-    },
-    "prettier-plugin-import-sort": {
       "optional": true
     },
     "prettier-plugin-jsdoc": {

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -181,7 +181,6 @@ async function loadCompatiblePlugins() {
     'prettier-plugin-multiline-arrays',
     '@ianvs/prettier-plugin-sort-imports',
     '@trivago/prettier-plugin-sort-imports',
-    'prettier-plugin-import-sort',
     'prettier-plugin-organize-imports',
     'prettier-plugin-sort-imports',
 

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -213,23 +213,6 @@ let tests: PluginTest[] = [
     },
   },
   {
-    // NOTE: This plugin doesn't officially support Prettier v3 but it seems to work fine
-    plugins: ['prettier-plugin-import-sort'],
-    tests: {
-      babel: [
-        [
-          `
-            import './three'
-            import '@one/file'
-            import '@two/file'
-            export default function Foo() { return <div className="sm:p-0 p-4"></div> }
-          `,
-          `import '@one/file'\nimport '@two/file'\n\nimport './three'\n\nexport default function Foo() {\n  return <div className="p-4 sm:p-0"></div>\n}`,
-        ],
-      ],
-    },
-  },
-  {
     plugins: ['prettier-plugin-jsdoc'],
     tests: {
       babel: [


### PR DESCRIPTION
The last update was over 4 years ago and pulls in old deps. Don’t think we need to keep it around.

Closes #297