### PR TITLE
Add bundled v4 fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handle quote escapes in LESS when sorting `@apply` ([#392](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/392))
 - Improved monorepo support by loading Tailwind CSS relative to the input file instead of prettier config file ([#386](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/386))
 - Improved monorepo support by loading v3 configs relative to the input file instead of prettier config file ([#386](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/386))
+- Fallback to Tailwind CSS v4 instead of v3 by default ([#390](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/390))
 
 ## [0.6.14] - 2025-07-09
 

--- a/build.mjs
+++ b/build.mjs
@@ -47,11 +47,11 @@ function patchCjsInterop() {
         let code = [
           `import {createRequire as __global__createRequire__} from 'module'`,
           `import {dirname as __global__dirname__} from 'path'`,
-          `import {fileURLToPath} from 'url'`,
+          `import {fileURLToPath as __global__fileURLToPath__} from 'url'`,
 
           // CJS interop fixes
           `const require=__global__createRequire__(import.meta.url)`,
-          `const __filename=fileURLToPath(import.meta.url)`,
+          `const __filename=__global__fileURLToPath__(import.meta.url)`,
           `const __dirname=__global__dirname__(__filename)`,
         ]
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -117,14 +117,6 @@ export async function getTailwindConfig(options: ParserOptions): Promise<any> {
     stylesheet ??= `${pkgDir}/theme.css`
   }
 
-  // No stylesheet was given or otherwise found in a local v4 installation
-  // nor was a tailwind config given or found.
-  //
-  // Fallback to v3
-  if (!stylesheet) {
-    return pathToApiMap.remember(null, () => loadV3(null, null))
-  }
-
   return pathToApiMap.remember(`${pkgDir}:${stylesheet}`, () => loadV4(mod, stylesheet))
 }
 

--- a/src/versions/assets.ts
+++ b/src/versions/assets.ts
@@ -1,0 +1,23 @@
+// @ts-ignore
+import index from 'tailwindcss-v4/index.css'
+// @ts-ignore
+import preflight from 'tailwindcss-v4/preflight.css'
+// @ts-ignore
+import theme from 'tailwindcss-v4/theme.css'
+// @ts-ignore
+import utilities from 'tailwindcss-v4/utilities.css'
+
+export const assets: Record<string, string> = {
+  tailwindcss: index,
+  'tailwindcss/index': index,
+  'tailwindcss/index.css': index,
+
+  'tailwindcss/preflight': preflight,
+  'tailwindcss/preflight.css': preflight,
+
+  'tailwindcss/theme': theme,
+  'tailwindcss/theme.css': theme,
+
+  'tailwindcss/utilities': utilities,
+  'tailwindcss/utilities.css': utilities,
+}

--- a/tests/fixtures.test.ts
+++ b/tests/fixtures.test.ts
@@ -17,6 +17,16 @@ let fixtures = [
     ext: 'html',
   },
   {
+    name: 'no local install of Tailwind CSS (uses v4)',
+    dir: 'no-local-version',
+    ext: 'html',
+  },
+  {
+    name: 'no stylesheet given (uses v4)',
+    dir: 'no-stylesheet-given',
+    ext: 'html',
+  },
+  {
     name: 'inferred config path',
     dir: 'basic',
     ext: 'html',

--- a/tests/fixtures/no-local-version/app.css
+++ b/tests/fixtures/no-local-version/app.css
@@ -1,0 +1,5 @@
+@import "tailwindcss";
+
+@theme {
+  --color-tomato: tomato;
+}

--- a/tests/fixtures/no-local-version/index.html
+++ b/tests/fixtures/no-local-version/index.html
@@ -1,0 +1,1 @@
+<div class="sm:bg-tomato bg-red-500"></div>

--- a/tests/fixtures/no-local-version/output.html
+++ b/tests/fixtures/no-local-version/output.html
@@ -1,0 +1,1 @@
+<div class="bg-red-500 sm:bg-tomato"></div>

--- a/tests/fixtures/no-local-version/package-lock.json
+++ b/tests/fixtures/no-local-version/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "no-local-version",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/tests/fixtures/no-local-version/package.json
+++ b/tests/fixtures/no-local-version/package.json
@@ -1,0 +1,5 @@
+{
+  "prettier": {
+    "tailwindStylesheet": "./app.css"
+  }
+}

--- a/tests/fixtures/no-stylesheet-given/index.html
+++ b/tests/fixtures/no-stylesheet-given/index.html
@@ -1,0 +1,1 @@
+<div class="sm:bg-red-500 bg-red-500"></div>

--- a/tests/fixtures/no-stylesheet-given/output.html
+++ b/tests/fixtures/no-stylesheet-given/output.html
@@ -1,0 +1,1 @@
+<div class="bg-red-500 sm:bg-red-500"></div>

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -26,6 +26,20 @@ describe('other', () => {
 
     expect(result).toEqual('<div class="unknown-class group peer container p-0"></div>')
   })
+
+  test('parasite utilities (v4)', async ({ expect }) => {
+    let result = await format('<div class="group peer unknown-class p-0 container"></div>', {
+      tailwindPackageName: 'tailwindcss-v4',
+    })
+
+    expect(result).toEqual('<div class="group peer unknown-class container p-0"></div>')
+  })
+
+  test('parasite utilities (no install == v4)', async ({ expect }) => {
+    let result = await format('<div class="group peer unknown-class p-0 container"></div>')
+
+    expect(result).toEqual('<div class="group peer unknown-class container p-0"></div>')
+  })
 })
 
 describe('whitespace', () => {
@@ -61,7 +75,7 @@ describe('whitespace', () => {
   test('duplicate classes are dropped', async ({ expect }) => {
     let result = await format('<div class="underline line-through underline flex"></div>')
 
-    expect(result).toEqual('<div class="flex underline line-through"></div>')
+    expect(result).toEqual('<div class="flex line-through underline"></div>')
   })
 })
 
@@ -90,6 +104,6 @@ describe('errors', () => {
       tailwindPackageName: 'tailwindcss-v3',
     })
 
-    await expect(result).rejects.toThrowError(/Unable to load Tailwind CSS v4/)
+    await expect(result).rejects.toThrowError(/no such file or directory/)
   })
 })


### PR DESCRIPTION
This bundles Tailwind CSS v4, it's relevant stylesheets, and intercepts their loading so users of the CDN or Standalone CLI can properly sort these without needing a local install through NPM.

**This is a breaking change**. We will still, however, search for a `tailwind.config.js` (or similar) in this scenario and load a bundled version of v3 if we find one. Specifying a stylesheet will force the plugin to load a bundled version of v4 if no local install exists.

Fixes #364