### PR TITLE
Handle quote escapes in LESS when sorting `@apply`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Format quotes in `@source`, `@plugin`, and `@config` ([#387](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/387))
 - Support sorting in callable template literals ([#367](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/367))
 - Support sorting in function calls mixed with property accesses ([#367](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/367))
+- Handle quote escapes in LESS when sorting `@apply` ([#392](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/392))
 
 ## [0.6.14] - 2025-07-09
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -810,7 +810,24 @@ function transformCss(ast: any, { env }: TransformerContext) {
         node.params,
       )
 
-      node.params = sortClasses(node.params, {
+      let classList = node.params
+
+      let prefix = ''
+      let suffix = ''
+
+      if (classList.startsWith('~"') && classList.endsWith('"')) {
+        prefix = '~"'
+        suffix = '"'
+        classList = classList.slice(2, -1)
+        isImportant = false
+      } else if (classList.startsWith("~'") && classList.endsWith("'")) {
+        prefix = "~'"
+        suffix = "'"
+        classList = classList.slice(2, -1)
+        isImportant = false
+      }
+
+      classList = sortClasses(classList, {
         env,
         ignoreLast: isImportant,
         collapseWhitespace: {
@@ -818,6 +835,8 @@ function transformCss(ast: any, { env }: TransformerContext) {
           end: !isImportant,
         },
       })
+
+      node.params = `${prefix}${classList}${suffix}`
     }
   })
 }

--- a/tests/tests.ts
+++ b/tests/tests.ts
@@ -266,7 +266,7 @@ export let tests: Record<string, TestEntry[]> = {
     t`@apply ${yes} #{'''!important'''};`,
     t`@apply ${yes} #{"'"'"!important"'"'"};`,
   ],
-  less: [...css, t`@apply ${yes} !important;`],
+  less: [...css, t`@apply ${yes} !important;`, t`@apply ~"${yes}";`, t`@apply ~'${yes}';`],
   babel: javascript,
   typescript: javascript,
   'babel-ts': javascript,


### PR DESCRIPTION
It’s perfect since the AST doesn’t actually have information on these (it’s just strings) but this should be good enough.

Fixes #323