### PR TITLE
Add options to match attributes by prefix and suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,28 @@ function MyButton({ children }) {
 }
 ```
 
+#### Matching attributes with a prefix or suffix
+
+```json5
+// .prettierrc
+{
+  "tailwindAttributesStartsWith": ["data"],
+  "tailwindAttributesEndsWith": ["ClassName"]
+}
+```
+
+With this configuration, attributes like `data-active-classes` and `buttonClassName` will be sorted:
+
+```jsx
+function MyButton({ children }) {
+  return (
+    <button buttonClassName="bg-blue-600 text-white">
+      {children}
+    </button>
+  );
+}
+```
+
 ## Sorting classes in function calls
 
 In addition to sorting classes in attributes, you can also sort classes in strings provided to function calls. This is useful when working with libraries like [clsx](https://github.com/lukeed/clsx) or [cva](https://cva.style/).

--- a/src/options.ts
+++ b/src/options.ts
@@ -31,6 +31,22 @@ export const options: Record<string, SupportOption> = {
     description: 'List of attributes/props that contain sortable Tailwind classes',
   },
 
+  tailwindAttributesStartsWith: {
+    type: 'string',
+    array: true,
+    default: [{ value: [] }],
+    category: 'Tailwind CSS',
+    description: 'List of prefixes for attributes that contain sortable Tailwind classes',
+  },
+
+  tailwindAttributesEndsWith: {
+    type: 'string',
+    array: true,
+    default: [{ value: [] }],
+    category: 'Tailwind CSS',
+    description: 'List of suffixes for attributes that contain sortable Tailwind classes',
+  },
+
   tailwindFunctions: {
     type: 'string',
     array: true,
@@ -63,6 +79,8 @@ export const options: Record<string, SupportOption> = {
 
 export function getCustomizations(options: RequiredOptions, parser: string, defaults: Customizations): Customizations {
   let staticAttrs = new Set<string>(defaults.staticAttrs)
+  let prefixAttrs = new Set<string>(defaults.prefixAttrs)
+  let suffixAttrs = new Set<string>(defaults.suffixAttrs)
   let dynamicAttrs = new Set<string>(defaults.dynamicAttrs)
   let functions = new Set<string>(defaults.functions)
 
@@ -96,9 +114,19 @@ export function getCustomizations(options: RequiredOptions, parser: string, defa
     functions.add(fn)
   }
 
+  for (let attr of options.tailwindAttributesStartsWith ?? []) {
+    prefixAttrs.add(attr)
+  }
+
+  for (let attr of options.tailwindAttributesEndsWith ?? []) {
+    suffixAttrs.add(attr)
+  }
+
   return {
     functions,
     staticAttrs,
     dynamicAttrs,
+    prefixAttrs,
+    suffixAttrs,
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,12 +4,16 @@ export interface TransformerMetadata {
   // Default customizations for a given transformer
   functions?: string[]
   staticAttrs?: string[]
+  prefixAttrs?: string[]
+  suffixAttrs?: string[]
   dynamicAttrs?: string[]
 }
 
 export interface Customizations {
   functions: Set<string>
   staticAttrs: Set<string>
+  prefixAttrs: Set<string>
+  suffixAttrs: Set<string>
   dynamicAttrs: Set<string>
 }
 


### PR DESCRIPTION
Hey! This PR introduces a new feature to enhance how the plugin discovers attributes containing Tailwind classes.

## Motivation

The plugin currently handles standard attributes like `class` and `className` very well. This change aims to expand that capability to support a wider range of projects that use their own unique naming conventions for styling.

For instance, some frameworks use prefixed attributes for dynamic classes, while component libraries often use props with specific suffixes (e.g., `wrapperClassName`, `iconClass`). This PR allows the plugin to recognize and sort classes within these types of custom attributes, making it more adaptable to different coding styles.

## How it Works

This is accomplished by adding two new options to the `.prettierrc.json`:

- `tailwindAttributesStartsWith`: An array of strings to match attributes that begin with a given prefix.
- `tailwindAttributesEndsWith`: An array of strings to match attributes that end with a given suffix.

### Example Configuration

For example, to handle the common `..ClassName` pattern, a user can update their `.prettierrc.json`:

```json5
{
  "plugins": ["prettier-plugin-tailwindcss"],
  "tailwindAttributesEndsWith": ["ClassName"]
}
```

With this configuration, attributes like `x-bind:class`, `wrapperClassName`, and `iconClass` will now be formatted correctly.

Happy to discuss and hear any feedback.