### PR TITLE
Bump Jiti to v2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "esbuild": "^0.25.9",
         "escalade": "^3.2.0",
         "import-sort-style-module": "^6.0.0",
-        "jiti": "^2.5.1",
+        "jiti": "^2.6.0",
         "jsesc": "^3.1.0",
         "license-checker": "^25.0.1",
         "line-column": "^1.0.2",
@@ -4067,9 +4067,9 @@
       "dev": true
     },
     "node_modules/jiti": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
-      "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.0.tgz",
+      "integrity": "sha512-VXe6RjJkBPj0ohtqaO8vSWP3ZhAKo66fKrFNCll4BTcwljPLz03pCbaNKfzGP5MbrCYcbJ7v0nOYYwUzTEIdXQ==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "esbuild": "^0.25.9",
     "escalade": "^3.2.0",
     "import-sort-style-module": "^6.0.0",
-    "jiti": "^2.5.1",
+    "jiti": "^2.6.0",
     "jsesc": "^3.1.0",
     "license-checker": "^25.0.1",
     "line-column": "^1.0.2",


### PR DESCRIPTION
v2.6.0 of Jiti comes with a nice perf bump from lazy loading babel only when necessary.