### PR TITLE
Add option to disable sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,28 @@ With this configuration, anything we perceive as duplicate classes will be prese
 </div>
 ```
 
+## Disabling sorting
+
+This plugin automatically sorts classes by default. If you want to disable sorting, you can use the `tailwindPreserveSortOrder` option:
+
+```json5
+// .prettierrc
+{
+  "tailwindPreserveSortOrder": true,
+}
+```
+With this configuration, classes will not be sorted:
+
+```jsx
+function MyButton({ children }) {
+  return (
+    <button className="rounded px-4 py-2 text-base text-white bg-blue-500">
+      {children}
+    </button>
+  )
+}
+```
+
 ## Compatibility with other Prettier plugins
 
 This plugin uses Prettier APIs that can only be used by one plugin at a time, making it incompatible with other Prettier plugins implemented the same way. To solve this we've added explicit per-plugin workarounds that enable compatibility with the following Prettier plugins:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1269,6 +1269,11 @@ export interface PluginOptions {
   tailwindAttributes?: string[]
 
   /**
+   * Preserve sort-order of Tailwind classes.
+   */
+  tailwindPreserveSortOrder?: boolean
+
+  /**
    * Preserve whitespace around Tailwind classes when sorting.
    */
   tailwindPreserveWhitespace?: boolean

--- a/src/options.ts
+++ b/src/options.ts
@@ -39,6 +39,13 @@ export const options: Record<string, SupportOption> = {
     description: 'List of functions and tagged templates that contain sortable Tailwind classes',
   },
 
+  tailwindPreserveSortOrder: {
+    type: 'boolean',
+    default: false,
+    category: 'Tailwind CSS',
+    description: 'Disable sorting of Tailwind classes',
+  },
+
   tailwindPreserveWhitespace: {
     type: 'boolean',
     default: false,

--- a/src/sorting.ts
+++ b/src/sorting.ts
@@ -4,6 +4,10 @@ import { bigSign } from './utils'
 function reorderClasses(classList: string[], { env }: { env: TransformerEnv }) {
   let orderedClasses = env.context.getClassOrder(classList)
 
+  if (env.options.tailwindPreserveSortOrder) {
+    return orderedClasses
+  }
+
   return orderedClasses.sort(([nameA, a], [nameZ, z]) => {
     // Move `...` to the end of the list
     if (nameA === '...' || nameA === '…') return 1

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -103,6 +103,83 @@ describe('whitespace', () => {
   })
 })
 
+describe('sort order', () => {
+  test('is disabled by default', async ({ expect }) => {
+    let result = await format('<div class="sm:lowercase uppercase potato text-sm"></div>')
+
+    expect(result).toEqual('<div class="potato text-sm uppercase sm:lowercase"></div>')
+  })
+  test('is disabled with explicit option', async ({ expect }) => {
+    let result = await format('<div class="sm:lowercase uppercase potato text-sm"></div>', {
+      tailwindPreserveSortOrder: false,
+    })
+
+    expect(result).toEqual('<div class="potato text-sm uppercase sm:lowercase"></div>')
+  })
+
+  test('can be preserved', async ({ expect }) => {
+    let result = await format('<div class="sm:lowercase uppercase potato text-sm"></div>', {
+      tailwindPreserveSortOrder: true,
+    })
+
+    expect(result).toEqual('<div class="sm:lowercase uppercase potato text-sm"></div>')
+  })
+
+  test('can be preserved with duplicates', async ({ expect }) => {
+    let result = await format('<div class="underline line-through underline flex"></div>', {
+      tailwindPreserveSortOrder: true,
+      tailwindPreserveDuplicates: true,
+    })
+
+    expect(result).toEqual('<div class="underline line-through underline flex"></div>')
+  })
+
+  test('can be preserved with whitespace', async ({ expect }) => {
+    let result = await format(`;<div className={' underline text-red-500  flex '}></div>`, {
+      parser: 'babel',
+      tailwindPreserveSortOrder: true,
+      tailwindPreserveWhitespace: true,
+    })
+
+    expect(result).toEqual(`;<div className={' underline text-red-500  flex '}></div>`)
+  })
+
+  test('can be preserved with duplicates and whitespace', async ({ expect }) => {
+    let result = await format(`;<div className={' underline line-through underline text-red-500  flex '}></div>`, {
+      parser: 'babel',
+      tailwindPreserveSortOrder: true,
+      tailwindPreserveWhitespace: true,
+      tailwindPreserveDuplicates: true,
+    })
+
+    expect(result).toEqual(`;<div className={' underline line-through underline text-red-500  flex '}></div>`)
+  })
+
+  test('is disabled by default with duplicates', async ({ expect }) => {
+    let result = await format('<div class="underline line-through underline flex"></div>')
+
+    expect(result).toEqual('<div class="flex line-through underline"></div>')
+  })
+
+  test('is disabled by default with whitespace', async ({ expect }) => {
+    let result = await format('<div class=" underline text-red-500  flex "></div>', {
+      tailwindPreserveWhitespace: true,
+    })
+
+    expect(result).toEqual('<div class="flex text-red-500 underline"></div>')
+  })
+
+  test('is disabled by default with duplicates and whitespace', async ({ expect }) => {
+    let result = await format(';<div class=" underline line-through underline text-red-500  flex "></div>', {
+      parser: 'babel',
+      tailwindPreserveWhitespace: true,
+      tailwindPreserveDuplicates: true,
+    })
+
+    expect(result).toEqual(';<div class=" flex text-red-500 line-through underline  underline "></div>')
+  })
+})
+
 describe('errors', () => {
   test('when the given JS config does not exist', async ({ expect }) => {
     let result = format('<div></div>', {


### PR DESCRIPTION
We love using Tailwind, but often wind up with extra-whitespace and/or duplicate properties. We'd love to adopt this plugin (but disable the "sorting" piece - we want to preserve our sort order).

I noticed that this plugin currently supports preserving whitespace and preserving duplicates - this PR adds the option to preserve sort-order, so you can get the whitespace & duplicate corrections without modifying the sort-order of the declarations.

I've added unit tests to verify that it works as-expected.