### PR TITLE
Fix class sorting in embedded code blocks when cwd differs from project dir

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,13 @@ import { cacheForDirs } from './utils.js'
 
 let prettierConfigCache = expiringMap<string, string | null>(10_000)
 
+// Tracks the last successfully resolved config directory. This is used as a
+// fallback when formatting embedded code blocks (e.g., tsx inside markdown)
+// where Prettier sets a synthetic filepath like "dummy.tsx" that cannot be used
+// for config resolution — especially in environments where process.cwd() does
+// not point to the project directory (e.g., the VS Code extension host).
+let lastResolvedConfigDir: string | null = null
+
 async function resolvePrettierConfigDir(
   filePath: string,
   inputDir: string,
@@ -17,7 +24,7 @@ async function resolvePrettierConfigDir(
   // Check cache for this directory
   let cached = prettierConfigCache.get(inputDir)
   if (cached !== undefined) {
-    return cached ?? process.cwd()
+    return cached ?? lastResolvedConfigDir ?? process.cwd()
   }
 
   const resolve = async () => {
@@ -35,11 +42,12 @@ async function resolvePrettierConfigDir(
   // Cache all directories from inputDir up to config location
   if (prettierConfig) {
     let configDir = path.dirname(prettierConfig)
+    lastResolvedConfigDir = configDir
     cacheForDirs(prettierConfigCache, inputDir, configDir, configDir)
     return configDir
   } else {
     prettierConfigCache.set(inputDir, null)
-    return process.cwd()
+    return lastResolvedConfigDir ?? process.cwd()
   }
 }
 


### PR DESCRIPTION
## Problem

Tailwind class sorting silently fails in embedded code blocks (e.g. ` ```tsx ` inside markdown) when `process.cwd()` does not point to the project directory. This commonly happens in the **VS Code Prettier extension**, where the extension host process has a different working directory than the project.

### Symptoms

- Classes in ` ```tsx ` / ` ```jsx ` code blocks inside markdown are **not sorted** when formatting via VS Code
- Classes in ` ```html ` code blocks **are sorted** (because Prettier does not set a synthetic filepath for html embeds)
- Both work correctly from the CLI (`npx prettier --write`)

### Root cause

When Prettier formats an embedded `tsx` code block inside markdown, it calls `textToDoc` with `{ parser: "typescript", filepath: "dummy.tsx" }`. This synthetic relative filepath causes `resolvePrettierConfigDir` to:

1. Compute `inputDir = path.dirname("dummy.tsx")` → `"."`
2. Call `prettier.resolveConfigFile("dummy.tsx")` which resolves relative to `process.cwd()`
3. Fail to find the config (cwd is wrong) → fall back to `process.cwd()`
4. Resolve `tailwindStylesheet` (a relative path like `"packages/react/styles/tailwind.css"`) against the wrong base directory
5. Silently fail to load the design system → no class sorting

For `html` code blocks, Prettier does **not** set a synthetic `filepath`, so `options.filepath` is inherited from the parent markdown file — which is an absolute path that resolves correctly.

### Reproduction

```js
// Run from a directory that is NOT the project root (e.g. /)
cd /
node --input-type=module -e "
import prettier from \"/path/to/project/node_modules/prettier/index.cjs\";

const md = \"\\\`\\\`\\\`tsx\\n<div className=\\\"bg-black w-2\\\">hello</div>\\n\\\`\\\`\\\`\\n\";

const result = await prettier.format(md, {
  filepath: \"/path/to/project/src/example.md\",
  parser: \"markdown\",
  plugins: [\"prettier-plugin-tailwindcss\"],
  tailwindStylesheet: \"src/styles.css\",  // relative path
});

// Expected: w-2 bg-black (sorted)
// Actual:   bg-black w-2 (unsorted)
console.log(result);
"
```

## Solution

Store the last successfully resolved config directory in a module-level variable and use it as a fallback when config resolution fails for embedded code blocks, instead of falling back to `process.cwd()`.

This is safe because within a single `prettier.format()` call, the parent file (e.g. the markdown file) is always parsed first — resolving the config correctly — before any embedded code blocks are formatted. The stored config directory is then available for the embedded parsers.

### Changes

3-line change in `src/config.ts`:

1. Add `lastResolvedConfigDir` variable
2. Store it when config is successfully resolved
3. Use `lastResolvedConfigDir ?? process.cwd()` instead of `process.cwd()` in both fallback paths

This preserves the existing behavior when cwd is correct, and fixes the embedded code block case when it is not.