### PR TITLE
Fix insiders tags sometimes published to latest channel

### DIFF
--- a/scripts/release-channel.js
+++ b/scripts/release-channel.js
@@ -16,7 +16,7 @@ const pkg = JSON.parse(await fs.readFile(path.resolve(__dirname, '../package.jso
 
 let version = process.argv[2] || process.env.npm_package_version || pkg.version
 
-let match = /\d+\.\d+\.\d+-(.*)\.\d+/g.exec(version)
+let match = /\d+\.\d+\.\d+-(.*)\./g.exec(version)
 if (match) {
   console.log(match[1])
 } else {


### PR DESCRIPTION
Credit to @0xsvenka for [discovering this](https://github.com/tailwindlabs/tailwindcss/discussions/19958).

As per [my findings](https://github.com/tailwindlabs/tailwindcss/discussions/19958#discussioncomment-16686421):

> It seems like the releases tagged `0.0.0-insiders.*` are incorrectly assigned the `latest` channel when published to NPM. I believe this is because [the regex](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/blob/main/scripts/release-channel.js#L19) to determine the channel does not resolve to be `insiders`. I.e. for `0.0.0-insiders.f7d2598`, we can see [in the GitHub workflow run](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/actions/runs/24828074666/job/72669130405#step:11:1) it is published to the `latest` channel. Compare this to `0.0.0-insiders.3b0ed57` which publishes correctly to `insiders`. This is because `0.0.0-insiders.3b0ed57` *does* match the regex.

This PR relaxes the regex to not need a digit after the dot (`.`), allowing matches for tags like `0.0.0-insiders.ffaa88`.