### PR TITLE
Fix compatible plugin chaining when prettier-vscode passes plugin.name as an absolute path on Windows.

### DIFF
--- a/src/create-plugin.ts
+++ b/src/create-plugin.ts
@@ -75,8 +75,39 @@ async function createParser({
   }
 
   parser.preprocess = async (code: string, options: ParserOptions) => {
-    let parser = await load(options)
-    return parser.preprocess ? parser.preprocess(code, options) : code
+    const compatibleNames = opts.compatible ?? []
+
+    const normalizePluginName = (pluginName: string) => {
+      const slashed = pluginName.replace(/\\/g, '/')
+
+      return compatibleNames.find((compatibleName) => slashed.includes(compatibleName)) ?? pluginName
+    }
+
+    const patchedOptions = {
+      ...options,
+      plugins: options.plugins.map((plugin) => {
+        if (typeof plugin === 'string') {
+          return plugin
+        }
+
+        if (plugin instanceof URL) {
+          return plugin
+        }
+
+        if (!plugin.name) {
+          return plugin
+        }
+
+        return {
+          ...plugin,
+          name: normalizePluginName(plugin.name),
+        }
+      }),
+    }
+
+    const parser = await load(patchedOptions)
+
+    return parser.preprocess ? parser.preprocess(code, patchedOptions) : code
   }
 
   parser.parse = async (code, options) => {
@@ -105,13 +136,7 @@ async function createParser({
   return parser
 }
 
-function createPrinter({
-  original,
-  opts,
-}: {
-  original: Printer<any>
-  opts: TransformOptions<any>
-}) {
+function createPrinter({ original, opts }: { original: Printer<any>; opts: TransformOptions<any> }) {
   let printer: Printer<any> = { ...original }
 
   let reprint = opts.reprint
@@ -203,10 +228,7 @@ function findEnabledPlugin(options: ParserOptions<any>, name: string) {
       plugin = plugin.name
     }
 
-    if (
-      plugin === name ||
-      (isAbsolute(plugin) && plugin.includes(name) && maybeResolve(name) === plugin)
-    ) {
+    if (plugin === name || (isAbsolute(plugin) && plugin.includes(name) && maybeResolve(name) === plugin)) {
       return loadIfExists<Plugin<any>>(name)
     }
   }


### PR DESCRIPTION
## What

Resolved a plugin chaining compatibility issue between:

* `@ianvs/prettier-plugin-sort-imports`
* `prettier-plugin-tailwindcss`

The issue started occurring on `prettier-plugin-tailwindcss >= 0.7.3`.

## Problem

In a Windows + pnpm + prettier-vscode environment, the following symptoms were observed:

* Depending on plugin order, only one feature worked:

  * import sorting
  * Tailwind class sorting
* VSCode format-on-save and CLI formatting produced different results
* `prettier-plugin-tailwindcss@0.7.2` worked correctly, while `0.7.3+` introduced the issue

Related issues:

* tailwindlabs/prettier-plugin-tailwindcss#455

## Root Cause

`prettier-plugin-tailwindcss` internally checks enabled plugins using plugin names.

However, in prettier-vscode on Windows, plugin names are resolved as native file paths:

```txt id="g2d1bm"
D:\...\@ianvs\prettier-plugin-sort-imports\...
```

while compatibility checks expect slash-based package names:

```txt id="jlwm1q"
@ianvs/prettier-plugin-sort-imports
```

Because Windows paths use backslashes (`\`), plugin chaining silently failed.

## Fix

Normalized plugin names before passing them into the parser chain.

```ts id="c7v0bo"
parser.preprocess = async (code: string, options: ParserOptions) => {
  const compatibleNames = opts.compatible ?? []

  const normalizePluginName = (pluginName: string) => {
    const slashed = pluginName.replace(/\\/g, '/')

    return (
      compatibleNames.find((compatibleName) =>
        slashed.includes(compatibleName),
      ) ?? pluginName
    )
  }

  const patchedOptions = {
    ...options,
    plugins: options.plugins.map((plugin) => {
      if (typeof plugin === 'string') {
        return plugin
      }

      if (plugin instanceof URL) {
        return plugin
      }

      if (!plugin.name) {
        return plugin
      }

      return {
        ...plugin,
        name: normalizePluginName(plugin.name),
      }
    }),
  }

  const parser = await load(patchedOptions)

  return parser.preprocess
    ? parser.preprocess(code, patchedOptions)
    : code
}
```

## Result

Both features now work correctly together:

* import sorting
* Tailwind class sorting

Verified in:

* Windows 11
* pnpm workspace
* prettier-vscode
* CLI (`prettier --write`)
