### PR TITLE
Add @ianvs/prettier-plugin-sort-imports to html transform compat list

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1056,7 +1056,10 @@ let html = defineTransform<HtmlNode>({
   staticAttrs: ['class'],
 
   load: [{ name: 'prettier/plugins/html', importer: () => import('prettier/plugins/html') }],
-  compatible: ['prettier-plugin-organize-attributes'],
+  compatible: [
+    'prettier-plugin-organize-attributes',
+    '@ianvs/prettier-plugin-sort-imports',
+  ],
 
   parsers: {
     html: {},


### PR DESCRIPTION
When using this plugin together with `@ianvs/prettier-plugin-sort-imports`, the two plugins conflict on `.vue` files depending on their order in the Prettier config.

Following `tailwindlabs/prettier-plugin-tailwindcss`'s [recommended placement](https://github.com/tailwindlabs/prettier-plugin-tailwindcss#compatibility-with-other-prettier-plugins) (placing it last), the sort-imports plugin won't take effect on `.vue` files. Reversing the order causes this plugin to stop working instead.

The root cause is that the `vue` parser lives under the `html` transform, whose `compatible` list only includes `prettier-plugin-organize-attributes` — missing `@ianvs/prettier-plugin-sort-imports`. The `js` transform already has it, which is why `.ts` files work fine.

This PR adds `@ianvs/prettier-plugin-sort-imports` to the `html` transform's `compatible` list, resolving the compatibility issue for `.vue` files.