### PR TITLE
Ensure compatibility for @trivago/prettier-plugin-sort-imports when using prettier-plugin-svelte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Don't remove escape sequences when sorting classes in JavaScript string literals, which could produce invalid code in Vue attribute expressions ([#461](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/461))
 - Restore class sorting in Svelte markup and dynamic `class={...}` expressions when using `prettier-plugin-svelte` v4 ([#462](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/462))
+- Enable compatibility with `@trivago/prettier-plugin-sort-imports` when using `prettier-plugin-svelte` ([#466](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/466))
 
 ## [0.8.0] - 2026-04-27
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1181,6 +1181,10 @@ type SvelteNode = import('svelte/compiler').AST.SvelteNode & {
 
 let svelte = defineTransform<SvelteNode>({
   staticAttrs: ['class'],
+  // Enforce README's "Compatibility with other Prettier plugins" with Svelte
+  // Only `@trivago/prettier-plugin-sort-imports` implements Svelte support.
+  // The other accepted import-sorting plugins do not register a `svelte` parser.
+  compatible: ['@trivago/prettier-plugin-sort-imports'],
   load: [{ name: 'prettier-plugin-svelte', importer: () => import('prettier-plugin-svelte') }],
 
   parsers: {

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -525,6 +525,40 @@ import Custom from '../components/Custom.astro'
       ],
     },
   },
+
+  // Ensures that @trivago/prettier-plugin-sort-imports plugin also works
+  // when used together with the svelte plugin, sorting imports inside a
+  // Svelte file's `<script>` block.
+  {
+    plugins: ['@trivago/prettier-plugin-sort-imports', 'prettier-plugin-svelte'],
+    options: {
+      importOrder: ['^@one/(.*)$', '^@two/(.*)$', '^[./]'],
+      importOrderSortSpecifiers: true,
+    },
+    tests: {
+      svelte: [
+        [
+          dedent`
+            <script>
+              import './three'
+              import '@two/file'
+              import '@one/file'
+            </script>
+            <div class="sm:p-0 p-0"></div>
+          `,
+          dedent`
+            <script>
+              import '@one/file'
+              import '@two/file'
+              import './three'
+            </script>
+
+            <div class="p-0 sm:p-0"></div>
+          `,
+        ],
+      ],
+    },
+  },
 ]
 
 for (const group of tests) {


### PR DESCRIPTION
Trivago's plugin offers Svelte support, but was ignored by the Svelte transform, despite the announced compatibility in the README (covered general compatibility, but missed Svelte; honest mistake).

Fixes #466.